### PR TITLE
OpenMP outer loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ gulinalg
 
 Linear algebra functions as Generalized Ufuncs.
 
-
 Notes about building
 ====================
 
@@ -11,8 +10,24 @@ This module is built using NumPy's configuration for LAPACK. This means that
 you need a setup similar to the one used to build the NumPy you are using. If
 you are building your own version of NumPy that should be the case.
 
+OpenMP support
+==============
+
+A subset of functions currently have openMP support via a `workers` argument
+that can be used to set the number of threads to use in the outer gufunc loop.
+
+On windows MSVC-style flags will be set, otherwise GCC-style flags (-fopenmp)
+are set. By default OpenMP is enabled, but if compilation of a simple test
+function fails, OpenMP will be disabled,
+
+The user can force OpenMP to always be disabled if desired by defining the
+environment variable GULINALG_DISABLE_OPENMP.
+
+If Intel's OpenMP library should be linked to, the user should specify the
+environment variable GULINALG_INTEL_OPENMP. This will cause libiomp5 to be
+linked during compilation (instead of GCC's libgomp).
+
 Build Status
 ============
 
 Travis CI: [![Build Status](https://travis-ci.org/Quansight/gulinalg.svg?branch=master)](https://travis-ci.org/Quansight/gulinalg)
-

--- a/gulinalg/gufunc_general.py
+++ b/gulinalg/gufunc_general.py
@@ -492,6 +492,7 @@ def update_rankk(a, c=None, UPLO='U', transpose_type='T', sym_out=True,
                     gufunc = _impl.update_rankk_down_sym
                 else:
                     gufunc = _impl.update_rankk_down
+
     workers, orig_workers = _check_workers(workers)
     try:
         out = gufunc(a, c, **kwargs)

--- a/gulinalg/gufunc_general.py
+++ b/gulinalg/gufunc_general.py
@@ -185,7 +185,7 @@ def innerwt(a, b, c, **kwargs):
     return _impl.innerwt(a, b, c, **kwargs)
 
 
-def matrix_multiply(a,b,**kwargs):
+def matrix_multiply(a, b, workers=1, **kwargs):
     """
     Compute matrix multiplication, with broadcasting
 
@@ -195,6 +195,10 @@ def matrix_multiply(a,b,**kwargs):
         Input array.
     b : (..., N, P) array
         Input array.
+    workers : int, optional
+        The number of parallel threads to use along gufunc loop dimension(s).
+        If set to -1, the maximum number of threads (as returned by
+        ``multiprocessing.cpu_count()``) are used.
 
     Returns
     -------
@@ -225,7 +229,14 @@ def matrix_multiply(a,b,**kwargs):
             [1030., 1088., 1146.]]])
 
     """
-    return _impl.matrix_multiply(a,b,**kwargs)
+    workers, orig_workers = _check_workers(workers)
+    try:
+        out =  _impl.matrix_multiply(a, b, **kwargs)
+    finally:
+        # restore original number of workers
+        if workers != orig_workers:
+            _impl.set_gufunc_threads(orig_workers)
+    return out
 
 
 def matvec_multiply(a, b, **kwargs):

--- a/gulinalg/src/conditional_omp.h
+++ b/gulinalg/src/conditional_omp.h
@@ -1,0 +1,30 @@
+/* Header file to conditionally wrap omp.h defines
+ *
+ * _OPENMP should be defined if omp.h is safe to include
+ */
+#if defined(_OPENMP)
+#include <omp.h>
+#define have_openmp 1
+#else
+/* These are fake defines to make these symbols valid in the c code
+ *
+ * Uses of these symbols should be within ``if (have_openmp)`` blocks:
+ *
+ *     if (have_openmp){
+ *         omp_set_num_threads(nthreads)
+ *     }
+ * */
+typedef int omp_lock_t;
+void omp_init_lock(omp_lock_t *lock) {};
+void omp_destroy_lock(omp_lock_t *lock) {};
+void omp_set_lock(omp_lock_t *lock) {};
+void omp_unset_lock(omp_lock_t *lock) {};
+int omp_test_lock(omp_lock_t *lock) {return 1;};
+void omp_set_dynamic(int dynamic_threads) {};
+void omp_set_num_threads(int num_threads) {};
+int omp_get_num_procs() {return 1;};
+int omp_get_max_threads() {return 1;};
+int omp_get_num_threads() {return 1;};
+int omp_get_thread_num() {return 1;};
+#define have_openmp 0
+#endif

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -5320,6 +5320,8 @@ static void
 typedef struct potrs_params_struct {
     void *A;
     void *B;
+    fortran_int A_size_bytes;
+    fortran_int B_size_bytes;
     fortran_int N;
     fortran_int NRHS;
     fortran_int LDA;
@@ -5339,14 +5341,17 @@ static inline int
 init_@lapack_func@(POTRS_PARAMS_t *params,
                    char UPLO,
                    fortran_int N,
-                   fortran_int NRHS)
+                   fortran_int NRHS,
+                   int omp_threads)
 {
     npy_uint8 *mem_buff = NULL;
     npy_uint8 *a, *b;
-    size_t a_size, b_size;
+    size_t a_size1, b_size1, a_size, b_size;
 
-    a_size = N*N*sizeof(@ftyp@);
-    b_size = N*NRHS*sizeof(@ftyp@);
+    a_size = N*N*omp_threads*sizeof(@ftyp@);
+    b_size = N*NRHS*omp_threads*sizeof(@ftyp@);
+    params->A_size_bytes = a_size;
+    params->B_size_bytes = b_size;
     mem_buff = malloc(a_size + b_size);
     if (!mem_buff)
       goto error;
@@ -5380,20 +5385,21 @@ release_@lapack_func@(POTRS_PARAMS_t *params)
 }
 
 static inline int
-call_@lapack_func@(POTRS_PARAMS_t *params)
+call_@lapack_func@(POTRS_PARAMS_t *params, void *A, void *B)
 {
+
     fortran_int rv;
     LAPACK(@lapack_func_2@)(&params->UPLO,
                             &params->N,
-                            params->A, &params->LDA,
+                            A, &params->LDA,
                             &rv);
     if (0 != rv)
         return rv;
 
     LAPACK(@lapack_func@)(&params->UPLO,
                           &params->N, &params->NRHS,
-                          params->A, &params->LDA,
-                          params->B, &params->LDB,
+                          A, &params->LDA,
+                          B, &params->LDB,
                           &rv);
     return rv;
 }
@@ -5414,9 +5420,23 @@ static void
     fortran_int n, nrhs;
     INIT_OUTER_LOOP_3
 
+    int orig_threads;
+    #pragma omp parallel
+    {
+        if (omp_get_thread_num() == 0)
+        {
+            orig_threads = omp_get_num_threads();
+        }
+    }
+
+    int max_threads = omp_get_max_threads();
+    int nthreads = max_threads < dN ? max_threads : dN;
+    omp_set_num_threads(nthreads);
+    // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
+
     n = (fortran_int)dimensions[0];
     nrhs = ndim?(fortran_int)dimensions[1]:1;
-    if (init_@lapack_func@(&params, uplo, n, nrhs)) {
+    if (init_@lapack_func@(&params, uplo, n, nrhs, nthreads)) {
         LINEARIZE_DATA_t a_in, b_in, r_out;
 
         init_linearize_data(&a_in, n, n, steps[1], steps[0]);
@@ -5428,20 +5448,29 @@ static void
             init_linearize_data(&r_out, 1, n, 0, steps[3]);
         }
 
-        BEGIN_OUTER_LOOP_3
+        // BEGIN_OUTER_LOOP_3
+        #pragma omp parallel for num_threads(nthreads)
+        for (N_ = 0; N_ < dN; N_++) {
             int not_ok;
-            linearize_@TYPE@_matrix(params.A, args[0], &a_in);
-            linearize_@TYPE@_matrix(params.B, args[1], &b_in);
-            not_ok = call_@lapack_func@(&params);
+
+            int id = omp_get_thread_num();
+            // printf("N_ = %d, thread ID = %d\n", (int)N_, id);
+            void *A = (void*)((char*)params.A + params.A_size_bytes * id);
+            void *B = (void*)((char*)params.B + params.B_size_bytes * id);
+
+            linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
+            linearize_@TYPE@_matrix(B, args[1] + s1 * N_, &b_in);
+            not_ok = call_@lapack_func@(&params, A, B);
             if (!not_ok) {
-                delinearize_@TYPE@_matrix(args[2], params.B, &r_out);
+                delinearize_@TYPE@_matrix(args[2] + s2 * N_, B, &r_out);
             } else {
                 error_occurred = 1;
-                nan_@TYPE@_matrix(args[2], &r_out);
+                nan_@TYPE@_matrix(args[2] + s2 * N_, &r_out);
             }
         END_OUTER_LOOP
 
         release_@lapack_func@(&params);
+        omp_set_num_threads(orig_threads);
     }
 
     set_fp_invalid_or_clear(error_occurred);

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -16,7 +16,7 @@
 #include <assert.h>
 #include <math.h>
 
-#include <omp.h>
+#include "conditional_omp.h"
 
 #ifdef _MSC_VER
 /* in Microsoft's C compiler "inline" is not valid, use "__inline" instead*/
@@ -1060,6 +1060,13 @@ dump_@TYPE@_matrix(const char* name,
              args[5] += s5) {
 
 #define END_OUTER_LOOP  }
+
+#define OMP_SET_ID \
+    int ID;\
+        if (have_openmp)\
+            ID = omp_get_thread_num();\
+        else\
+            ID = 0;
 
 static inline void
 update_pointers(npy_uint8** bases, ptrdiff_t* offsets, size_t count)
@@ -2209,19 +2216,22 @@ static void
 
     size_t sot = sizeof(@typ@);
 
-    int orig_threads;
-    #pragma omp parallel
+    int max_threads=1, nthreads=1, orig_threads=1;
+    if (have_openmp)
     {
-        if (omp_get_thread_num() == 0)
+        #pragma omp parallel
         {
-            orig_threads = omp_get_num_threads();
+            if (omp_get_thread_num() == 0)
+            {
+                orig_threads = omp_get_num_threads();
+            }
         }
+        max_threads = omp_get_max_threads();
+        nthreads = max_threads < dN ? max_threads : dN;
+        omp_set_num_threads(nthreads);
+        // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
     }
 
-    int max_threads = omp_get_max_threads();
-    int nthreads = max_threads < dN ? max_threads : dN;
-    omp_set_num_threads(nthreads);
-    // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
     if (init_syrk_params(&params, n, k, trans, steps, sot, nthreads, 0))
     {
         LINEARIZE_DATA_t a_in, c_in, r_out;
@@ -2229,11 +2239,9 @@ static void
         init_linearize_data(&c_in, n, n, steps[3], steps[2]);
         init_linearize_data(&r_out, n, n, steps[5], steps[4]);
 
-        /* Don't use BEGIN_OUTPUT_LOOP3 template as we need to increment
+        /* Don't use BEGIN_OUTER_LOOP3 template as we need to increment
          * offsets on a per-thread basis in the parallel for loop instead
          */
-
-        // printf("omp_get_num_threads (outer) = %d\n", omp_get_num_threads());
 
         #pragma omp parallel for num_threads(nthreads)
         for (N_ = 0; N_ < dN; N_++) {
@@ -2244,7 +2252,9 @@ static void
              * To avoid thread conflicts, A, C point to a specific offset for
              * each thread
              */
-            int ID = omp_get_thread_num();
+
+            OMP_SET_ID
+
             // printf("N_ = %d, thread ID = %d\n", (int)N_, ID);
             void *A = params.A + params.A_size_bytes * ID;
             void *C = params.C + params.C_size_bytes * ID;
@@ -2278,7 +2288,8 @@ static void
         END_OUTER_LOOP
 
         release_syrk_params(&params);
-        omp_set_num_threads(orig_threads);
+        if (have_openmp)
+            omp_set_num_threads(orig_threads);
     }
 }
 
@@ -2346,18 +2357,21 @@ static void
 
     size_t sot = sizeof(@typ@);
 
-    int orig_threads;
-    #pragma omp parallel
+    int max_threads=1, nthreads=1, orig_threads=1;
+    if (have_openmp)
     {
-        if (omp_get_thread_num() == 0)
+        #pragma omp parallel
         {
-            orig_threads = omp_get_num_threads();
+            if (omp_get_thread_num() == 0)
+            {
+                orig_threads = omp_get_num_threads();
+            }
         }
+        max_threads = omp_get_max_threads();
+        nthreads = max_threads < dN ? max_threads : dN;
+        omp_set_num_threads(nthreads);
+        // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
     }
-
-    int max_threads = omp_get_max_threads();
-    int nthreads = max_threads < dN ? max_threads : dN;
-    omp_set_num_threads(nthreads);
 
     int avoid_C_allocation = 1;
     if (init_syrk_params(&params, n, k, trans, steps, sot, nthreads, avoid_C_allocation))
@@ -2369,8 +2383,7 @@ static void
         //BEGIN_OUTER_LOOP_2
         #pragma omp parallel for num_threads(nthreads)
         for (N_ = 0; N_ < dN; N_++) {
-            int ID = omp_get_thread_num();
-            // printf("N_ = %d, thread ID = %d\n", (int)N_, ID);
+            OMP_SET_ID
             void *A = params.A + params.A_size_bytes * ID;
 
             linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
@@ -2419,7 +2432,8 @@ static void
         END_OUTER_LOOP
 
         release_syrk_params(&params);
-        omp_set_num_threads(orig_threads);
+        if (have_openmp)
+            omp_set_num_threads(orig_threads);
     }
 }
 
@@ -3164,11 +3178,13 @@ static void
         #pragma omp parallel for num_threads(nthreads) schedule(static)
         for (N_ = 0; N_ < dN; N_++) {
             int not_ok;
-            int id = omp_get_thread_num();
-            // printf("N_ = %d, thread ID = %d\n", (int)N_, id);
-            void *A = params.A + params.A_size_bytes * id;
-            void *B = params.B + params.B_size_bytes * id;
-            fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * id);
+
+            OMP_SET_ID
+
+            // printf("N_ = %d, thread ID = %d\n", (int)N_, ID);
+            void *A = params.A + params.A_size_bytes * ID;
+            void *B = params.B + params.B_size_bytes * ID;
+            fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * ID);
 
             linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
             linearize_@TYPE@_matrix(B, args[1] + s1 * N_, &b_in);
@@ -3222,11 +3238,11 @@ static void
         #pragma omp parallel for num_threads(nthreads)
         for (N_ = 0; N_ < dN; N_++) {
             int not_ok;
-            int id = omp_get_thread_num();
-            // printf("N_ = %d, thread ID = %d\n", (int)N_, id);
-            void *A = params.A + params.A_size_bytes * id;
-            void *B = params.B + params.B_size_bytes * id;
-            fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * id);
+            OMP_SET_ID
+            // printf("N_ = %d, thread ID = %d\n", (int)N_, ID);
+            void *A = params.A + params.A_size_bytes * ID;
+            void *B = params.B + params.B_size_bytes * ID;
+            fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * ID);
 
             linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
             linearize_@TYPE@_matrix(B, args[1] + s1 * N_, &b_in);
@@ -3279,10 +3295,10 @@ static void
         #pragma omp parallel for num_threads(nthreads)
         for (N_ = 0; N_ < dN; N_++) {
             int not_ok;
-            int id = omp_get_thread_num();
-            void *A = params.A + params.A_size_bytes * id;
-            void *B = params.B + params.B_size_bytes * id;
-            fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * id);
+            OMP_SET_ID
+            void *A = params.A + params.A_size_bytes * ID;
+            void *B = params.B + params.B_size_bytes * ID;
+            fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * ID);
 
             linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
             identity_@TYPE@_matrix(B, n);
@@ -5531,10 +5547,10 @@ static void
         for (N_ = 0; N_ < dN; N_++) {
             int not_ok;
 
-            int id = omp_get_thread_num();
-            // printf("N_ = %d, thread ID = %d\n", (int)N_, id);
-            void *A = params.A + params.A_size_bytes * id;
-            void *B = params.B + params.B_size_bytes * id;
+            OMP_SET_ID
+            // printf("N_ = %d, thread ID = %d\n", (int)N_, ID);
+            void *A = params.A + params.A_size_bytes * ID;
+            void *B = params.B + params.B_size_bytes * ID;
 
             linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
             linearize_@TYPE@_matrix(B, args[1] + s1 * N_, &b_in);

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -16,6 +16,8 @@
 #include <assert.h>
 #include <math.h>
 
+#include <omp.h>
+
 #ifdef _MSC_VER
 /* in Microsoft's C compiler "inline" is not valid, use "__inline" instead*/
 #  define inline __inline
@@ -2114,6 +2116,8 @@ typedef struct syrk_params_struct
 {
     void *A;
     void *C;
+    fortran_int A_size_bytes;
+    fortran_int C_size_bytes;
     fortran_int N;
     fortran_int K;
     fortran_int LDA;
@@ -2127,18 +2131,22 @@ init_syrk_params(SYRK_PARAMS_t *params,
                  char trans,
                  npy_intp* steps,
                  size_t sot,
-                 int no_C)
+                 int no_C,
+                 int omp_threads)
 {
     size_t a_size = n * k * sot;
     size_t c_size = no_C ? 0 : n * n * sot;
-    npy_uint8 *mem_buff = malloc(a_size + c_size);
+    params->A_size_bytes = a_size;
+    params->C_size_bytes = c_size;
+
+    npy_uint8 *mem_buff = malloc((a_size + c_size) * omp_threads);
     if (!mem_buff) {
         memset(params, 0, sizeof(*params));
         return 0;
     }
 
     params->A = mem_buff;
-    params->C = no_C ? NULL: mem_buff + a_size;
+    params->C = no_C ? NULL: mem_buff + a_size * omp_threads;
     if (trans=='N'){
         params->LDA = n;  // must be at least max(1, n)
     } else {
@@ -2201,16 +2209,48 @@ static void
 
     size_t sot = sizeof(@typ@);
 
-    if (init_syrk_params(&params, n, k, trans, steps, sot, 0))
+    int orig_threads;
+    #pragma omp parallel
+    {
+        if (omp_get_thread_num() == 0)
+        {
+            orig_threads = omp_get_num_threads();
+        }
+    }
+
+    int max_threads = omp_get_max_threads();
+    int nthreads = max_threads < dN ? max_threads : dN;
+    omp_set_num_threads(nthreads);
+    // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
+    if (init_syrk_params(&params, n, k, trans, steps, sot, nthreads, 0))
     {
         LINEARIZE_DATA_t a_in, c_in, r_out;
         init_linearize_data(&a_in, k, n, steps[1], steps[0]);
         init_linearize_data(&c_in, n, n, steps[3], steps[2]);
         init_linearize_data(&r_out, n, n, steps[5], steps[4]);
 
-        BEGIN_OUTER_LOOP_3
-            linearize_@TYPE@_matrix(params.A, args[0], &a_in);
-            linearize_@TYPE@_matrix(params.C, args[1], &c_in);
+        /* Don't use BEGIN_OUTPUT_LOOP3 template as we need to increment
+         * offsets on a per-thread basis in the parallel for loop instead
+         */
+
+        // printf("omp_get_num_threads (outer) = %d\n", omp_get_num_threads());
+
+        #pragma omp parallel for num_threads(nthreads)
+        for (N_ = 0; N_ < dN; N_++) {
+
+            // printf("omp_get_num_threads = %d\n", omp_get_num_threads());
+            /* With OpenMP threads, params.A is size n * k * threads
+             *                      params.C is size n * n * threads
+             * To avoid thread conflicts, A, C point to a specific offset for
+             * each thread
+             */
+            int ID = omp_get_thread_num();
+            // printf("N_ = %d, thread ID = %d\n", (int)N_, ID);
+            void *A = (void*)((char*)params.A + params.A_size_bytes * ID);
+            void *C = (void*)((char*)params.C + params.C_size_bytes * ID);
+
+            linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
+            linearize_@TYPE@_matrix(C, args[1] + s1 * N_, &c_in);
 
             /*
              * To get rank-k update, invoke syrk_.
@@ -2223,21 +2263,22 @@ static void
                            &params.N,
                            &params.K,
                            (void*)&@one@, // alpha (default=1.0)
-                           params.A,
+                           A,
                            &params.LDA,
                            (void*)&@one@, // beta (default=1.0)
-                           params.C,
+                           C,
                            &params.LDC);
 
             /* Copy Fortran matrix returned by SYRK to output argument */
             if (symmetric)
             {
-                make_symmetric_@TYPE@_matrix(uplo, params.N, params.C);
+                make_symmetric_@TYPE@_matrix(uplo, params.N, C);
             }
-            delinearize_@TYPE@_matrix(args[2], params.C, &r_out);
+            delinearize_@TYPE@_matrix(args[2] + s2 * N_, C, &r_out);
         END_OUTER_LOOP
 
         release_syrk_params(&params);
+        omp_set_num_threads(orig_threads);
     }
 }
 
@@ -2305,31 +2346,46 @@ static void
 
     size_t sot = sizeof(@typ@);
 
+    int orig_threads;
+    #pragma omp parallel
+    {
+        if (omp_get_thread_num() == 0)
+        {
+            orig_threads = omp_get_num_threads();
+        }
+    }
+
+    int max_threads = omp_get_max_threads();
+    int nthreads = max_threads < dN ? max_threads : dN;
+    omp_set_num_threads(nthreads);
 
     int avoid_C_allocation = 1;
-    if (init_syrk_params(&params, n, k, trans, steps, sot, avoid_C_allocation))
+    if (init_syrk_params(&params, n, k, trans, steps, sot, nthreads, avoid_C_allocation))
     {
         LINEARIZE_DATA_t a_in, r_out;
         init_linearize_data(&a_in, k, n, steps[1], steps[0]);
         init_linearize_data(&r_out, n, n, steps[3], steps[2]);
 
-        BEGIN_OUTER_LOOP_2
-            linearize_@TYPE@_matrix(params.A, args[0], &a_in);
+        //BEGIN_OUTER_LOOP_2
+        #pragma omp parallel for num_threads(nthreads)
+        for (N_ = 0; N_ < dN; N_++) {
+            int ID = omp_get_thread_num();
+            // printf("N_ = %d, thread ID = %d\n", (int)N_, ID);
+            void *A = params.A + params.A_size_bytes * ID;
 
-
+            linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
             // params.C will be NULL: called init_syrk_params with no_C=1
             void *pC;
             if (avoid_C_allocation)
             {
                 // operate on the output array directly
-                zero_@TYPE@_matrix(args[1], &r_out);
+                zero_@TYPE@_matrix(args[1] + s1 * N_, &r_out);
                 pC = args[1];
             } else {
-                linearize_@TYPE@_matrix(params.C, args[1], &a_in);
+                linearize_@TYPE@_matrix(params.C, args[1] + s1 * N_, &a_in);
                 zero_@TYPE@_matrix(params.C, &r_out);
                 pC = params.C;
             }
-
 
             /*
              * To get rank-k update, invoke syrk_.
@@ -2358,11 +2414,12 @@ static void
              * out.swapaxes(-2, -1) in the Python caller
              */
             if (avoid_C_allocation == 0) {
-                delinearize_@TYPE@_matrix(args[1], params.C, &r_out);
+                delinearize_@TYPE@_matrix(args[1] + s1 * N_, pC, &r_out);
             }
         END_OUTER_LOOP
 
         release_syrk_params(&params);
+        omp_set_num_threads(orig_threads);
     }
 }
 

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -85,6 +85,7 @@ typedef int sgeev_type(char *jobvl, char *jobvr, int *n,
                        float vl[], int *ldvl, float vr[], int *ldvr,
                        float work[], int lwork[],
                        int *info);
+
 typedef int dgeev_type(char *jobvl, char *jobvr, int *n,
                        double a[], int *lda, double wr[], double wi[],
                        double vl[], int *ldvl, double vr[], int *ldvr,
@@ -289,10 +290,13 @@ typedef int zpotri_type(char *uplo, int *n,
 
 typedef int slaswp_type(int *n, float *a, int *lda,
                        int *k1, int *k2, int *ipiv, int *incx);
+
 typedef int dlaswp_type(int *n, double *a, int *lda,
                        int *k1, int *k2, int *ipiv, int *incx);
+
 typedef int claswp_type(int *n, f2c_complex *a, int *lda,
                        int *k1, int *k2, int *ipiv, int *incx);
+
 typedef int zlaswp_type(int *n, f2c_doublecomplex *a, int *lda,
                        int *k1, int *k2, int *ipiv, int *incx);
 
@@ -1777,7 +1781,8 @@ static void
     INIT_OUTER_LOOP_3
 
     int max_threads=1, nthreads=1, orig_threads=1;
-    if (have_openmp)
+    int use_openmp = have_openmp && dN > 1;
+    if (use_openmp)
     {
         #pragma omp parallel
         {
@@ -1789,7 +1794,6 @@ static void
         max_threads = omp_get_max_threads();
         nthreads = max_threads < dN ? max_threads : dN;
         omp_set_num_threads(nthreads);
-        // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
     }
 
     m = (fortran_int) dimensions[0];
@@ -1845,6 +1849,7 @@ static void
                 void *pA = params.A + params.A_size_bytes * ID;
                 void *pB = params.B + params.B_size_bytes * ID;
                 void *pC = params.C + params.C_size_bytes * ID;
+
                 /* just call the appropriate multiply and update pointers */
                 @typ@ *A = linearize_@TYPE@_matrix(pA, args[swapped] + sA * N_, &a_in);
                 @typ@ *B = linearize_@TYPE@_matrix(pB, args[1-swapped] + sB * N_, &b_in);
@@ -1867,7 +1872,8 @@ static void
         END_OUTER_LOOP
 
         release_gemm_params(&params);
-        omp_set_num_threads(orig_threads);
+        if (use_openmp)
+            omp_set_num_threads(orig_threads);
     }
 }
 
@@ -2268,7 +2274,8 @@ static void
     size_t sot = sizeof(@typ@);
 
     int max_threads=1, nthreads=1, orig_threads=1;
-    if (have_openmp)
+    int use_openmp = have_openmp && dN > 1;
+    if (use_openmp)
     {
         #pragma omp parallel
         {
@@ -2280,7 +2287,6 @@ static void
         max_threads = omp_get_max_threads();
         nthreads = max_threads < dN ? max_threads : dN;
         omp_set_num_threads(nthreads);
-        // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
     }
 
     if (init_syrk_params(&params, n, k, trans, steps, sot, nthreads, 0))
@@ -2306,7 +2312,6 @@ static void
 
             OMP_SET_ID
 
-            // printf("N_ = %d, thread ID = %d\n", (int)N_, ID);
             void *A = params.A + params.A_size_bytes * ID;
             void *C = params.C + params.C_size_bytes * ID;
 
@@ -2339,7 +2344,7 @@ static void
         END_OUTER_LOOP
 
         release_syrk_params(&params);
-        if (have_openmp)
+        if (use_openmp)
             omp_set_num_threads(orig_threads);
     }
 }
@@ -2409,7 +2414,8 @@ static void
     size_t sot = sizeof(@typ@);
 
     int max_threads=1, nthreads=1, orig_threads=1;
-    if (have_openmp)
+    int use_openmp = have_openmp && dN > 1;
+    if (use_openmp)
     {
         #pragma omp parallel
         {
@@ -2421,7 +2427,6 @@ static void
         max_threads = omp_get_max_threads();
         nthreads = max_threads < dN ? max_threads : dN;
         omp_set_num_threads(nthreads);
-        // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
     }
 
     if (init_syrk_params(&params, n, k, trans, steps, sot, nthreads, 1))
@@ -2433,7 +2438,9 @@ static void
         //BEGIN_OUTER_LOOP_2
         #pragma omp parallel for num_threads(nthreads)
         for (N_ = 0; N_ < dN; N_++) {
+
             OMP_SET_ID
+
             void *A = params.A + params.A_size_bytes * ID;
             void *C;
 
@@ -2475,7 +2482,7 @@ static void
         END_OUTER_LOOP
 
         release_syrk_params(&params);
-        if (have_openmp)
+        if (use_openmp)
             omp_set_num_threads(orig_threads);
     }
 }
@@ -3194,19 +3201,22 @@ static void
     int error_occurred = get_fp_invalid_and_clear();
     INIT_OUTER_LOOP_3
 
-    int orig_threads;
-    #pragma omp parallel
-    {
-        if (omp_get_thread_num() == 0)
-        {
-            orig_threads = omp_get_num_threads();
-        }
-    }
+    int max_threads=1, nthreads=1, orig_threads=1;
+    int use_openmp = have_openmp && dN > 1;
+    if (use_openmp)
 
-    int max_threads = omp_get_max_threads();
-    int nthreads = max_threads < dN ? max_threads : dN;
-    omp_set_num_threads(nthreads);
-    // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
+    {
+        #pragma omp parallel
+        {
+            if (omp_get_thread_num() == 0)
+            {
+                orig_threads = omp_get_num_threads();
+            }
+        }
+        max_threads = omp_get_max_threads();
+        nthreads = max_threads < dN ? max_threads : dN;
+        omp_set_num_threads(nthreads);
+    }
 
     n = (fortran_int)dimensions[0];
     nrhs = (fortran_int)dimensions[1];
@@ -3224,7 +3234,6 @@ static void
 
             OMP_SET_ID
 
-            // printf("N_ = %d, thread ID = %d\n", (int)N_, ID);
             void *A = params.A + params.A_size_bytes * ID;
             void *B = params.B + params.B_size_bytes * ID;
             fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * ID);
@@ -3241,7 +3250,9 @@ static void
         END_OUTER_LOOP
 
         release_@lapack_func@(&params);
-        omp_set_num_threads(orig_threads);
+        if (use_openmp)
+            omp_set_num_threads(orig_threads);
+
     }
 
     set_fp_invalid_or_clear(error_occurred);
@@ -3256,19 +3267,21 @@ static void
     fortran_int n;
     INIT_OUTER_LOOP_3
 
-    int orig_threads;
-    #pragma omp parallel
+    int max_threads=1, nthreads=1, orig_threads=1;
+    int use_openmp = have_openmp && dN > 1;
+    if (use_openmp)
     {
-        if (omp_get_thread_num() == 0)
+        #pragma omp parallel
         {
-            orig_threads = omp_get_num_threads();
+            if (omp_get_thread_num() == 0)
+            {
+                orig_threads = omp_get_num_threads();
+            }
         }
+        max_threads = omp_get_max_threads();
+        nthreads = max_threads < dN ? max_threads : dN;
+        omp_set_num_threads(nthreads);
     }
-
-    int max_threads = omp_get_max_threads();
-    int nthreads = max_threads < dN ? max_threads : dN;
-    omp_set_num_threads(nthreads);
-    // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
 
     n = (fortran_int)dimensions[0];
     if (init_@lapack_func@(&params, n, 1, nthreads)) {
@@ -3281,8 +3294,9 @@ static void
         #pragma omp parallel for num_threads(nthreads)
         for (N_ = 0; N_ < dN; N_++) {
             int not_ok;
+
             OMP_SET_ID
-            // printf("N_ = %d, thread ID = %d\n", (int)N_, ID);
+
             void *A = params.A + params.A_size_bytes * ID;
             void *B = params.B + params.B_size_bytes * ID;
             fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * ID);
@@ -3299,7 +3313,8 @@ static void
         END_OUTER_LOOP
 
         release_@lapack_func@(&params);
-        omp_set_num_threads(orig_threads);
+        if (use_openmp)
+            omp_set_num_threads(orig_threads);
     }
 
     set_fp_invalid_or_clear(error_occurred);
@@ -3314,19 +3329,21 @@ static void
     int error_occurred = get_fp_invalid_and_clear();
     INIT_OUTER_LOOP_2
 
-    int orig_threads;
-    #pragma omp parallel
+    int max_threads=1, nthreads=1, orig_threads=1;
+    int use_openmp = have_openmp && dN > 1;
+    if (use_openmp)
     {
-        if (omp_get_thread_num() == 0)
+        #pragma omp parallel
         {
-            orig_threads = omp_get_num_threads();
+            if (omp_get_thread_num() == 0)
+            {
+                orig_threads = omp_get_num_threads();
+            }
         }
+        max_threads = omp_get_max_threads();
+        nthreads = max_threads < dN ? max_threads : dN;
+        omp_set_num_threads(nthreads);
     }
-
-    int max_threads = omp_get_max_threads();
-    int nthreads = max_threads < dN ? max_threads : dN;
-    omp_set_num_threads(nthreads);
-    // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
 
     n = (fortran_int)dimensions[0];
     if (init_@lapack_func@(&params, n, n, nthreads)) {
@@ -3338,7 +3355,9 @@ static void
         #pragma omp parallel for num_threads(nthreads)
         for (N_ = 0; N_ < dN; N_++) {
             int not_ok;
+
             OMP_SET_ID
+
             void *A = params.A + params.A_size_bytes * ID;
             void *B = params.B + params.B_size_bytes * ID;
             fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * ID);
@@ -3358,7 +3377,8 @@ static void
     }
 
     set_fp_invalid_or_clear(error_occurred);
-    omp_set_num_threads(orig_threads);
+    if (use_openmp)
+        omp_set_num_threads(orig_threads);
 }
 
 /**end repeat**/
@@ -5557,19 +5577,21 @@ static void
     fortran_int n, nrhs;
     INIT_OUTER_LOOP_3
 
-    int orig_threads;
-    #pragma omp parallel
+    int max_threads=1, nthreads=1, orig_threads=1;
+    int use_openmp = have_openmp && dN > 1;
+    if (use_openmp)
     {
-        if (omp_get_thread_num() == 0)
+        #pragma omp parallel
         {
-            orig_threads = omp_get_num_threads();
+            if (omp_get_thread_num() == 0)
+            {
+                orig_threads = omp_get_num_threads();
+            }
         }
+        max_threads = omp_get_max_threads();
+        nthreads = max_threads < dN ? max_threads : dN;
+        omp_set_num_threads(nthreads);
     }
-
-    int max_threads = omp_get_max_threads();
-    int nthreads = max_threads < dN ? max_threads : dN;
-    omp_set_num_threads(nthreads);
-    // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
 
     n = (fortran_int)dimensions[0];
     nrhs = ndim?(fortran_int)dimensions[1]:1;
@@ -5591,7 +5613,7 @@ static void
             int not_ok;
 
             OMP_SET_ID
-            // printf("N_ = %d, thread ID = %d\n", (int)N_, ID);
+
             void *A = params.A + params.A_size_bytes * ID;
             void *B = params.B + params.B_size_bytes * ID;
 
@@ -5607,7 +5629,8 @@ static void
         END_OUTER_LOOP
 
         release_@lapack_func@(&params);
-        omp_set_num_threads(orig_threads);
+        if (use_openmp)
+            omp_set_num_threads(orig_threads);
     }
 
     set_fp_invalid_or_clear(error_occurred);

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -2246,8 +2246,8 @@ static void
              */
             int ID = omp_get_thread_num();
             // printf("N_ = %d, thread ID = %d\n", (int)N_, ID);
-            void *A = (void*)((char*)params.A + params.A_size_bytes * ID);
-            void *C = (void*)((char*)params.C + params.C_size_bytes * ID);
+            void *A = params.A + params.A_size_bytes * ID;
+            void *C = params.C + params.C_size_bytes * ID;
 
             linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
             linearize_@TYPE@_matrix(C, args[1] + s1 * N_, &c_in);
@@ -3052,6 +3052,10 @@ typedef struct gesv_params_struct
     void *B; /* B is (N,NRHS) of base type */
     fortran_int * IPIV; /* IPIV is (N) */
 
+    fortran_int A_size_bytes;
+    fortran_int B_size_bytes;
+    fortran_int IPIV_size_bytes;
+
     fortran_int N;
     fortran_int NRHS;
     fortran_int LDA;
@@ -3070,18 +3074,23 @@ typedef struct gesv_params_struct
  * Handles buffer allocation
  */
 static inline int
-init_@lapack_func@(GESV_PARAMS_t *params, fortran_int N, fortran_int NRHS)
+init_@lapack_func@(GESV_PARAMS_t *params, fortran_int N, fortran_int NRHS,
+                   int omp_threads)
 {
     npy_uint8 *mem_buff = NULL;
     npy_uint8 *a, *b, *ipiv;
-    mem_buff = malloc(N*N*sizeof(@ftyp@) +
-                      N*NRHS*sizeof(@ftyp@) +
-                      N*sizeof(fortran_int));
+    params->A_size_bytes = N*N*sizeof(@ftyp@);
+    params->B_size_bytes = N*NRHS*sizeof(@ftyp@);
+    params->IPIV_size_bytes = N*sizeof(fortran_int);
+
+    mem_buff = malloc(params->A_size_bytes*omp_threads +
+                      params->B_size_bytes*omp_threads +
+                      params->IPIV_size_bytes*omp_threads);
     if (!mem_buff)
         goto error;
     a = mem_buff;
-    b = a + N*N*sizeof(@ftyp@);
-    ipiv = b + N*NRHS*sizeof(@ftyp@);
+    b = a + params->A_size_bytes*omp_threads;
+    ipiv = b + params->B_size_bytes*omp_threads;
 
     params->A = a;
     params->B = b;
@@ -3108,13 +3117,13 @@ release_@lapack_func@(GESV_PARAMS_t *params)
 }
 
 static inline fortran_int
-call_@lapack_func@(GESV_PARAMS_t *params)
+call_@lapack_func@(GESV_PARAMS_t *params, void *A, void *B, fortran_int *IPIV)
 {
     fortran_int rv;
     LAPACK(@lapack_func@)(&params->N, &params->NRHS,
-                          params->A, &params->LDA,
-                          params->IPIV,
-                          params->B, &params->LDB,
+                          A, &params->LDA,
+                          IPIV,
+                          B, &params->LDB,
                           &rv);
     return rv;
 }
@@ -3128,29 +3137,52 @@ static void
     int error_occurred = get_fp_invalid_and_clear();
     INIT_OUTER_LOOP_3
 
+    int orig_threads;
+    #pragma omp parallel
+    {
+        if (omp_get_thread_num() == 0)
+        {
+            orig_threads = omp_get_num_threads();
+        }
+    }
+
+    int max_threads = omp_get_max_threads();
+    int nthreads = max_threads < dN ? max_threads : dN;
+    omp_set_num_threads(nthreads);
+    // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
+
     n = (fortran_int)dimensions[0];
     nrhs = (fortran_int)dimensions[1];
-    if (init_@lapack_func@(&params, n, nrhs)) {
+    if (init_@lapack_func@(&params, n, nrhs, nthreads)) {
         LINEARIZE_DATA_t a_in, b_in, r_out;
 
         init_linearize_data(&a_in, n, n, steps[1], steps[0]);
         init_linearize_data(&b_in, nrhs, n, steps[3], steps[2]);
         init_linearize_data(&r_out, nrhs, n, steps[5], steps[4]);
 
-        BEGIN_OUTER_LOOP_3
+        // BEGIN_OUTER_LOOP_3
+        #pragma omp parallel for num_threads(nthreads) schedule(static)
+        for (N_ = 0; N_ < dN; N_++) {
             int not_ok;
-            linearize_@TYPE@_matrix(params.A, args[0], &a_in);
-            linearize_@TYPE@_matrix(params.B, args[1], &b_in);
-            not_ok =call_@lapack_func@(&params);
+            int id = omp_get_thread_num();
+            // printf("N_ = %d, thread ID = %d\n", (int)N_, id);
+            void *A = params.A + params.A_size_bytes * id;
+            void *B = params.B + params.B_size_bytes * id;
+            fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * id);
+
+            linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
+            linearize_@TYPE@_matrix(B, args[1] + s1 * N_, &b_in);
+            not_ok =call_@lapack_func@(&params, A, B, IPIV);
             if (!not_ok) {
-                delinearize_@TYPE@_matrix(args[2], params.B, &r_out);
+                delinearize_@TYPE@_matrix(args[2] + s2 * N_, B, &r_out);
             } else {
                 error_occurred = 1;
-                nan_@TYPE@_matrix(args[2], &r_out);
+                nan_@TYPE@_matrix(args[2] + s2 * N_, &r_out);
             }
         END_OUTER_LOOP
 
         release_@lapack_func@(&params);
+        omp_set_num_threads(orig_threads);
     }
 
     set_fp_invalid_or_clear(error_occurred);
@@ -3165,27 +3197,50 @@ static void
     fortran_int n;
     INIT_OUTER_LOOP_3
 
+    int orig_threads;
+    #pragma omp parallel
+    {
+        if (omp_get_thread_num() == 0)
+        {
+            orig_threads = omp_get_num_threads();
+        }
+    }
+
+    int max_threads = omp_get_max_threads();
+    int nthreads = max_threads < dN ? max_threads : dN;
+    omp_set_num_threads(nthreads);
+    // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
+
     n = (fortran_int)dimensions[0];
-    if (init_@lapack_func@(&params, n, 1)) {
+    if (init_@lapack_func@(&params, n, 1, nthreads)) {
         LINEARIZE_DATA_t a_in, b_in, r_out;
         init_linearize_data(&a_in, n, n, steps[1], steps[0]);
         init_linearize_data(&b_in, 1, n, 1, steps[2]);
         init_linearize_data(&r_out, 1, n, 1, steps[3]);
 
-        BEGIN_OUTER_LOOP_3
+        // BEGIN_OUTER_LOOP_3
+        #pragma omp parallel for num_threads(nthreads)
+        for (N_ = 0; N_ < dN; N_++) {
             int not_ok;
-            linearize_@TYPE@_matrix(params.A, args[0], &a_in);
-            linearize_@TYPE@_matrix(params.B, args[1], &b_in);
-            not_ok = call_@lapack_func@(&params);
+            int id = omp_get_thread_num();
+            // printf("N_ = %d, thread ID = %d\n", (int)N_, id);
+            void *A = params.A + params.A_size_bytes * id;
+            void *B = params.B + params.B_size_bytes * id;
+            fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * id);
+
+            linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
+            linearize_@TYPE@_matrix(B, args[1] + s1 * N_, &b_in);
+            not_ok = call_@lapack_func@(&params, A, B, IPIV);
             if (!not_ok) {
-                delinearize_@TYPE@_matrix(args[2], params.B, &r_out);
+                delinearize_@TYPE@_matrix(args[2] + s2 * N_, B, &r_out);
             } else {
                 error_occurred = 1;
-                nan_@TYPE@_matrix(args[2], &r_out);
+                nan_@TYPE@_matrix(args[2] + s2 * N_, &r_out);
             }
         END_OUTER_LOOP
 
         release_@lapack_func@(&params);
+        omp_set_num_threads(orig_threads);
     }
 
     set_fp_invalid_or_clear(error_occurred);
@@ -3200,22 +3255,43 @@ static void
     int error_occurred = get_fp_invalid_and_clear();
     INIT_OUTER_LOOP_2
 
+    int orig_threads;
+    #pragma omp parallel
+    {
+        if (omp_get_thread_num() == 0)
+        {
+            orig_threads = omp_get_num_threads();
+        }
+    }
+
+    int max_threads = omp_get_max_threads();
+    int nthreads = max_threads < dN ? max_threads : dN;
+    omp_set_num_threads(nthreads);
+    // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
+
     n = (fortran_int)dimensions[0];
-    if (init_@lapack_func@(&params, n, n)) {
+    if (init_@lapack_func@(&params, n, n, nthreads)) {
         LINEARIZE_DATA_t a_in, r_out;
         init_linearize_data(&a_in, n, n, steps[1], steps[0]);
         init_linearize_data(&r_out, n, n, steps[3], steps[2]);
 
-        BEGIN_OUTER_LOOP_2
+        //BEGIN_OUTER_LOOP_2
+        #pragma omp parallel for num_threads(nthreads)
+        for (N_ = 0; N_ < dN; N_++) {
             int not_ok;
-            linearize_@TYPE@_matrix(params.A, args[0], &a_in);
-            identity_@TYPE@_matrix(params.B, n);
-            not_ok = call_@lapack_func@(&params);
+            int id = omp_get_thread_num();
+            void *A = params.A + params.A_size_bytes * id;
+            void *B = params.B + params.B_size_bytes * id;
+            fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * id);
+
+            linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
+            identity_@TYPE@_matrix(B, n);
+            not_ok = call_@lapack_func@(&params, A, B, IPIV);
             if (!not_ok) {
-                delinearize_@TYPE@_matrix(args[1], params.B, &r_out);
+                delinearize_@TYPE@_matrix(args[1] + s1 * N_, B, &r_out);
             } else {
                 error_occurred = 1;
-                nan_@TYPE@_matrix(args[1], &r_out);
+                nan_@TYPE@_matrix(args[1] + s1 * N_, &r_out);
             }
         END_OUTER_LOOP
 
@@ -3223,6 +3299,7 @@ static void
     }
 
     set_fp_invalid_or_clear(error_occurred);
+    omp_set_num_threads(orig_threads);
 }
 
 /**end repeat**/
@@ -5346,18 +5423,18 @@ init_@lapack_func@(POTRS_PARAMS_t *params,
 {
     npy_uint8 *mem_buff = NULL;
     npy_uint8 *a, *b;
-    size_t a_size1, b_size1, a_size, b_size;
+    size_t a_size, b_size;
 
-    a_size = N*N*omp_threads*sizeof(@ftyp@);
-    b_size = N*NRHS*omp_threads*sizeof(@ftyp@);
+    a_size = N*N*sizeof(@ftyp@);
+    b_size = N*NRHS*sizeof(@ftyp@);
     params->A_size_bytes = a_size;
     params->B_size_bytes = b_size;
-    mem_buff = malloc(a_size + b_size);
+    mem_buff = malloc(a_size*omp_threads + b_size*omp_threads);
     if (!mem_buff)
       goto error;
 
     a = mem_buff;
-    b = a + a_size;
+    b = a + a_size*omp_threads;
 
     params->A = (void*)a;
     params->B = (void*)b;
@@ -5370,6 +5447,7 @@ init_@lapack_func@(POTRS_PARAMS_t *params,
     return 1;
 
  error:
+    printf("init allocation error\n");
     free(mem_buff);
     memset(params, 0, sizeof(*params));
 
@@ -5455,8 +5533,8 @@ static void
 
             int id = omp_get_thread_num();
             // printf("N_ = %d, thread ID = %d\n", (int)N_, id);
-            void *A = (void*)((char*)params.A + params.A_size_bytes * id);
-            void *B = (void*)((char*)params.B + params.B_size_bytes * id);
+            void *A = params.A + params.A_size_bytes * id;
+            void *B = params.B + params.B_size_bytes * id;
 
             linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
             linearize_@TYPE@_matrix(B, args[1] + s1 * N_, &b_in);

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -2138,8 +2138,8 @@ init_syrk_params(SYRK_PARAMS_t *params,
                  char trans,
                  npy_intp* steps,
                  size_t sot,
-                 int no_C,
-                 int omp_threads)
+                 int omp_threads,
+                 int no_C)
 {
     size_t a_size = n * k * sot;
     size_t c_size = no_C ? 0 : n * n * sot;
@@ -2373,8 +2373,7 @@ static void
         // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
     }
 
-    int avoid_C_allocation = 1;
-    if (init_syrk_params(&params, n, k, trans, steps, sot, nthreads, avoid_C_allocation))
+    if (init_syrk_params(&params, n, k, trans, steps, sot, nthreads, 1))
     {
         LINEARIZE_DATA_t a_in, r_out;
         init_linearize_data(&a_in, k, n, steps[1], steps[0]);
@@ -2385,20 +2384,15 @@ static void
         for (N_ = 0; N_ < dN; N_++) {
             OMP_SET_ID
             void *A = params.A + params.A_size_bytes * ID;
+            void *C;
 
             linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
             // params.C will be NULL: called init_syrk_params with no_C=1
             void *pC;
-            if (avoid_C_allocation)
-            {
-                // operate on the output array directly
-                zero_@TYPE@_matrix(args[1] + s1 * N_, &r_out);
-                pC = args[1];
-            } else {
-                linearize_@TYPE@_matrix(params.C, args[1] + s1 * N_, &a_in);
-                zero_@TYPE@_matrix(params.C, &r_out);
-                pC = params.C;
-            }
+
+            // operate on the output array directly
+            C = args[1] + s1 * N_;
+            zero_@TYPE@_matrix(C, &r_out);
 
             /*
              * To get rank-k update, invoke syrk_.
@@ -2411,24 +2405,22 @@ static void
                            &params.N,
                            &params.K,
                            (void*)&@one@, // alpha (default=1.0)
-                           params.A,
+                           A,
                            &params.LDA,
                            (void*)&@zero@, // beta (default=0.0)
-                           pC,  // C
+                           C,
                            &params.LDC);
 
             if (symmetric)
             {
-                make_symmetric_@TYPE@_matrix(uplo, params.N, pC);
+                make_symmetric_@TYPE@_matrix(uplo, params.N, C);
             }
 
-            /* Copy Fortran matrix returned by SYRK to output argument */
-            /* when parms.C is NULL we will have to call
+            /* Note: SYRK output, C, is stored in Fortran order
+             * when symmetric is false, we will have to call
              * out.swapaxes(-2, -1) in the Python caller
              */
-            if (avoid_C_allocation == 0) {
-                delinearize_@TYPE@_matrix(args[1] + s1 * N_, pC, &r_out);
-            }
+
         END_OUTER_LOOP
 
         release_syrk_params(&params);

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -6918,7 +6918,33 @@ check_strict_fp( void )
 #endif
 
 
+static PyObject *
+Py_set_omp_threads(PyObject *self, PyObject *args)
+{
+    int nthreads;
+    if (!PyArg_ParseTuple(args, "i", &nthreads))
+        return NULL;
+    omp_set_num_threads(nthreads);
+    return PyLong_FromLong(nthreads);
+}
+
+static PyObject *
+Py_get_omp_threads(PyObject *self, PyObject *args)
+{
+    int nthreads = 1;
+    #pragma omp parallel
+    {
+        if (omp_get_thread_num() == 0)
+        {
+            nthreads = omp_get_num_threads();
+        }
+    }
+    return PyLong_FromLong(nthreads);
+}
+
 static PyMethodDef UMath_LinAlgMethods[] = {
+    {"set_omp_threads", (PyCFunction)Py_set_omp_threads, METH_VARARGS, NULL},
+    {"get_omp_threads", (PyCFunction)Py_get_omp_threads, METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -1539,6 +1539,9 @@ typedef struct gemm_params_struct
     void *A;
     void *B;
     void *C;
+    fortran_int A_size_bytes;
+    fortran_int B_size_bytes;
+    fortran_int C_size_bytes;
     fortran_int LDA;
     fortran_int LDB;
     fortran_int LDC;
@@ -1559,10 +1562,13 @@ dump_gemm_params(const char* name, const GEMM_PARAMS_t* params)
               "%14s: %18p\n" "%14s: %18p\n" "%14s: %18p\n"
               "%14s: %18d\n" "%14s: %18d\n" "%14s: %18d\n"
               "%14s: %18d\n" "%14s: %18d\n" "%14s: %18d\n"
+              "%14s: %18d\n" "%14s: %18d\n" "%14s: %18d\n"
               "%14s: %15c'%c'\n" "%14s: %15c'%c'\n"
               "%14s: %18s\n",
               name,
               "A", params->A, "B", params->B, "C", params->C,
+              "Asize", params->A_size_bytes, "Bsize", params->B_size_bytes,
+              "Csize", params->C_size_bytes,
               "LDA", params->LDA, "LDB", params->LDB, "LDC", params->LDC,
               "M", params->M, "K", params->K, "N", params->N,
               "TRANSA", ' ', params->TRANSA, "TRANSB", ' ', params->TRANSB,
@@ -1572,7 +1578,8 @@ dump_gemm_params(const char* name, const GEMM_PARAMS_t* params)
 
 typedef struct _matrix_desc {
     fortran_int lead;
-    size_t size;
+    size_t size1;  // size of a single matrix
+    size_t size;   /// size of omp_threads matrices
     void *buff;
     int transposed;
 } matrix_desc;
@@ -1583,7 +1590,8 @@ matrix_desc_init(matrix_desc *mtxd,
                  npy_intp* steps,
                  size_t sot,
                  fortran_int rows,
-                 fortran_int columns)
+                 fortran_int columns,
+                 fortran_int omp_threads)
 /* initialized a matrix desc based on the information in steps
    it will fill the matrix desc with the values needed.
 
@@ -1595,6 +1603,7 @@ matrix_desc_init(matrix_desc *mtxd,
              be generated for single and double)
    rows    - number of rows in the matrix (or length of column) rows >= 1
    columns - number of columns in the matrix (or length of row) columns >= 1
+   omp_threads - number of OpenMP threads to use
 
 */
 {
@@ -1616,6 +1625,7 @@ matrix_desc_init(matrix_desc *mtxd,
             row_stride / sot >= rows) { /* lead will be >= max(1, columns) */
             /* Can use directly, non transposed "FORTRAN" array */
             mtxd->lead = row_stride / sot;
+            mtxd->size1 = 0;
             mtxd->size = 0;
             mtxd->buff = NULL;
             mtxd->transposed = 0; /* normal */
@@ -1628,6 +1638,7 @@ matrix_desc_init(matrix_desc *mtxd,
             col_stride / sot >= columns) { /* lead will be >= max(1, rows) */
             /* Can use directly, transposed "FORTRAN" array -C array- */
             mtxd->lead = col_stride / sot;
+            mtxd->size1 = 0;
             mtxd->size = 0;
             mtxd->buff = NULL;
             mtxd->transposed = 1; /* Transposed */
@@ -1638,10 +1649,10 @@ matrix_desc_init(matrix_desc *mtxd,
     /* If we reach this point, we will need a copy. Setup as a column major array
        by default */
     mtxd->lead = rows;
-    mtxd->size = rows*columns*sot; /* this being non zero means a buff is needed */
+    mtxd->size1 = rows*columns*sot; /* this being non zero means a buff is needed */
+    mtxd->size = mtxd->size1 * omp_threads;
     mtxd->buff = NULL;
     mtxd->transposed = 0; /* normal */
-
 }
 
 static inline npy_uint8 *
@@ -1661,24 +1672,25 @@ init_gemm_params(GEMM_PARAMS_t *params,
                  fortran_int k,
                  fortran_int n,
                  npy_intp* steps,
-                 size_t sot)
+                 size_t sot,
+                 int omp_threads)
 {
     int swap_args = 0;
     npy_uint8 *mem_buff = NULL;
     matrix_desc a, b, c;
-    matrix_desc_init(&c, steps + 4, sot, m, n);
+    matrix_desc_init(&c, steps + 4, sot, m, n, omp_threads);
     if (!c.transposed) {
         /* either the result is in FORTRAN order or a copy is needed for
            the output */
-        matrix_desc_init(&a, steps + 0, sot, m, k);
-        matrix_desc_init(&b, steps + 2, sot, k, n);
+        matrix_desc_init(&a, steps + 0, sot, m, k, omp_threads);
+        matrix_desc_init(&b, steps + 2, sot, k, n, omp_threads);
     } else {
         /* note that this implies that the result buffer is "dense" but that
            it expects the result in C order. We will be able to deal with that
            by using the identity B.T x A.T == AB.T*/
         c.transposed = 0;
-        matrix_desc_init(&a, steps + 2, sot, k, n);
-        matrix_desc_init(&b, steps + 0, sot, m, k);
+        matrix_desc_init(&a, steps + 2, sot, k, n, omp_threads);
+        matrix_desc_init(&b, steps + 0, sot, m, k, omp_threads);
         /* transpose the matrix_descs */
         a.transposed = 1 - a.transposed;
         b.transposed = 1 - b.transposed;
@@ -1709,6 +1721,9 @@ init_gemm_params(GEMM_PARAMS_t *params,
     params->A = a.buff;
     params->B = b.buff;
     params->C = c.buff;
+    params->A_size_bytes = a.size1;
+    params->B_size_bytes = b.size1;
+    params->C_size_bytes = c.size1;
     params->LDA = a.lead;
     params->LDB = b.lead;
     params->LDC = c.lead;
@@ -1761,16 +1776,43 @@ static void
 
     INIT_OUTER_LOOP_3
 
+    int max_threads=1, nthreads=1, orig_threads=1;
+    if (have_openmp)
+    {
+        #pragma omp parallel
+        {
+            if (omp_get_thread_num() == 0)
+            {
+                orig_threads = omp_get_num_threads();
+            }
+        }
+        max_threads = omp_get_max_threads();
+        nthreads = max_threads < dN ? max_threads : dN;
+        omp_set_num_threads(nthreads);
+        // printf("dN = %d, nthreads = %d\n", (int)dN, nthreads);
+    }
+
     m = (fortran_int) dimensions[0];
     k = (fortran_int) dimensions[1];
     n = (fortran_int) dimensions[2];
     if (m == 0 || n == 0)
         return; /* output array will be empty, as one of its inner dimensions will be 0 */
 
-    if (init_gemm_params(&params, m, k, n, steps, sizeof(@typ@)))
+    if (init_gemm_params(&params, m, k, n, steps, sizeof(@typ@), nthreads))
     {
         int swapped = params.swap_args;
         LINEARIZE_DATA_t a_in, b_in, c_out;
+
+        npy_intp sA, sB, sC;
+
+        if (!swapped) {
+            sA = s0;
+            sB = s1;
+        } else {
+            sA = s1;
+            sB = s0;
+        }
+        sC = s2;
 
         if (k != 0) {
             if (!swapped) {
@@ -1793,12 +1835,20 @@ static void
             init_linearize_data(&c_out, n, m, steps[5], steps[4]);
         }
 
-        BEGIN_OUTER_LOOP_3
+        //BEGIN_OUTER_LOOP_3
+        #pragma omp parallel for num_threads(nthreads)
+        for (N_ = 0; N_ < dN; N_++) {
+
+            OMP_SET_ID
+
             if (k != 0) {
+                void *pA = params.A + params.A_size_bytes * ID;
+                void *pB = params.B + params.B_size_bytes * ID;
+                void *pC = params.C + params.C_size_bytes * ID;
                 /* just call the appropriate multiply and update pointers */
-                @typ@ *A = linearize_@TYPE@_matrix(params.A, args[swapped], &a_in);
-                @typ@ *B = linearize_@TYPE@_matrix(params.B, args[1-swapped], &b_in);
-                @typ@ *C = params.C ? (@typ@*)params.C : (@typ@ *) args[2];
+                @typ@ *A = linearize_@TYPE@_matrix(pA, args[swapped] + sA * N_, &a_in);
+                @typ@ *B = linearize_@TYPE@_matrix(pB, args[1-swapped] + sB * N_, &b_in);
+                @typ@ *C = params.C ? (@typ@*)pC : (@typ@ *) (args[2] + sC * N_);
 
                 /* linearize source operands if needed */
                 /* (M, K) x (K, N) -> (M, N) */
@@ -1809,14 +1859,15 @@ static void
                               (void*)B, &params.LDB,
                               (void*)&@zero@, // beta
                               (void*)C, &params.LDC);
-                delinearize_@TYPE@_matrix(args[2], params.C, &c_out);
+                delinearize_@TYPE@_matrix(args[2] + sC * N_, pC, &c_out);
             } else {
                 /* if K is 0, then fill the result with zeros */
-                zero_@TYPE@_matrix(args[2], &c_out);
+                zero_@TYPE@_matrix(args[2] + sC * N_, &c_out);
             }
         END_OUTER_LOOP
 
         release_gemm_params(&params);
+        omp_set_num_threads(orig_threads);
     }
 }
 
@@ -1852,7 +1903,7 @@ init_gemv_params(GEMV_PARAMS_t *params,
      * array, allocate one.
      */
     matrix_desc a;
-    matrix_desc_init(&a, steps + 0, sot, m, n);
+    matrix_desc_init(&a, steps + 0, sot, m, n, 1);
     if (a.size)
     {
         npy_uint8 *current;

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -6943,8 +6943,8 @@ Py_get_omp_threads(PyObject *self, PyObject *args)
 }
 
 static PyMethodDef UMath_LinAlgMethods[] = {
-    {"set_omp_threads", (PyCFunction)Py_set_omp_threads, METH_VARARGS, NULL},
-    {"get_omp_threads", (PyCFunction)Py_get_omp_threads, METH_VARARGS, NULL},
+    {"set_gufunc_threads", (PyCFunction)Py_set_omp_threads, METH_VARARGS, NULL},
+    {"get_gufunc_threads", (PyCFunction)Py_get_omp_threads, METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -2182,6 +2182,7 @@ typedef struct syrk_params_struct
     void *C;
     fortran_int A_size_bytes;
     fortran_int C_size_bytes;
+    char TRANSA;
     fortran_int N;
     fortran_int K;
     fortran_int LDA;
@@ -2192,30 +2193,63 @@ static inline int
 init_syrk_params(SYRK_PARAMS_t *params,
                  fortran_int n,
                  fortran_int k,
-                 char trans,
                  npy_intp* steps,
                  size_t sot,
                  int omp_threads,
                  int no_C)
 {
-    size_t a_size = n * k * sot;
-    size_t c_size = no_C ? 0 : n * n * sot;
+
+    npy_int a_col_stride = steps[0];
+    npy_int a_row_stride = steps[1];
+
+    int a_transposed = 0;
+
+    size_t a_size = NULL;
+
+    /* maybe row major */
+    if (a_row_stride == sot && /* dense rows */
+        a_col_stride % sot == 0 && /* elements aligned */
+        a_col_stride / sot >= k) { /* lead will be >= max(1, rows) */
+        /* Can use directly, transposed "FORTRAN" array -C array- */
+        a_transposed = 1; /* Transposed */
+        params->LDA = k;
+    } else if (a_col_stride == sot && /* dense columns */
+        a_row_stride % sot == 0 && /* elements aligned */
+        a_row_stride / sot >= n) { /* lead will be >= max(1, columns) */
+        /* Can use directly, non transposed "FORTRAN" array */
+        a_transposed = 0; /* Transposed */
+        params->LDA = n;
+    } else {
+        params->LDA = n;
+        a_size = n * k * sot;
+    }
+
+    size_t c_size = no_C ? NULL : n * n * sot;
     params->A_size_bytes = a_size;
     params->C_size_bytes = c_size;
 
-    npy_uint8 *mem_buff = malloc((a_size + c_size) * omp_threads);
-    if (!mem_buff) {
-        memset(params, 0, sizeof(*params));
-        return 0;
+    npy_uint8 *mem_buff = NULL;
+    npy_uint8 *mem_buff2 = NULL;
+    if (a_size)
+    {
+        mem_buff = malloc((a_size + c_size) * omp_threads);
+        if (!mem_buff) {
+            memset(params, 0, sizeof(*params));
+            return 0;
+        }
+    }
+    if (c_size)
+    {
+        mem_buff2 = malloc((a_size + c_size) * omp_threads);
+        if (!mem_buff2) {
+            memset(params, 0, sizeof(*params));
+            return 0;
+        }
     }
 
     params->A = mem_buff;
-    params->C = no_C ? NULL: mem_buff + a_size * omp_threads;
-    if (trans=='N'){
-        params->LDA = n;  // must be at least max(1, n)
-    } else {
-        params->LDA = k;  // must be at least max(1, k)
-    }
+    params->TRANSA="NT"[a_transposed];
+    params->C = mem_buff2;
     params->LDC = n;  // must be at least max(1, n)
     params->N = n;
     params->K = k;
@@ -2228,6 +2262,8 @@ release_syrk_params(SYRK_PARAMS_t * params)
 {
     free(params->A);
     params->A = NULL;
+    free(params->C);
+    params->C = NULL;
 }
 
 /**begin repeat
@@ -2240,11 +2276,9 @@ release_syrk_params(SYRK_PARAMS_t * params)
 
 /*
  *   uplo:  'U' - C is upper triangular matrix. 'L' - Lower triangular.
- *   trans: 'N' - No transpose, 'T' - Transpose, 'C' - Conjugate transpose.
  */
 static void
 @TYPE@_update_rankk_common(char uplo,
-                           char trans,
                            char **args,
                            npy_intp *dimensions,
                            npy_intp *steps,
@@ -2255,18 +2289,11 @@ static void
 
     INIT_OUTER_LOOP_3
 
-    if (trans == 'N') {
-        n = (fortran_int) dimensions[0];
-        k = (fortran_int) dimensions[1];
-    }
-    else {
-        /* TODO: fix trans != N case. currently this branch is never called
-           because gufunc_general.py does the transpose so that this function
-           is always called with trans == 'N'
-         */
-        k = (fortran_int) dimensions[0];
-        n = (fortran_int) dimensions[1];
-    }
+    npy_intp step_n, step_k;
+    n = (fortran_int) dimensions[0];
+    k = (fortran_int) dimensions[1];
+    step_n = steps[0];
+    step_k = steps[1];
 
     if (k == 0 || n == 0)
         return; /* output array will be empty, as one of its inner dimensions will be 0 */
@@ -2289,10 +2316,16 @@ static void
         omp_set_num_threads(nthreads);
     }
 
-    if (init_syrk_params(&params, n, k, trans, steps, sot, nthreads, 0))
+    if (init_syrk_params(&params, n, k, steps, sot, nthreads, 0))
     {
         LINEARIZE_DATA_t a_in, c_in, r_out;
-        init_linearize_data(&a_in, k, n, steps[1], steps[0]);
+        if (params.A) {
+            /*
+             * Input matrix isn't dense. Since BLAS routine expects that in
+             * contiguous memory locations, flatten input into params.A.
+             */
+            init_linearize_data(&a_in, k, n, step_k, step_n);
+        }
         init_linearize_data(&c_in, n, n, steps[3], steps[2]);
         init_linearize_data(&r_out, n, n, steps[5], steps[4]);
 
@@ -2303,7 +2336,6 @@ static void
         #pragma omp parallel for num_threads(nthreads)
         for (N_ = 0; N_ < dN; N_++) {
 
-            // printf("omp_get_num_threads = %d\n", omp_get_num_threads());
             /* With OpenMP threads, params.A is size n * k * threads
              *                      params.C is size n * n * threads
              * To avoid thread conflicts, A, C point to a specific offset for
@@ -2312,10 +2344,17 @@ static void
 
             OMP_SET_ID
 
-            void *A = params.A + params.A_size_bytes * ID;
+            void *A;
             void *C = params.C + params.C_size_bytes * ID;
 
-            linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
+            if (params.A)
+            {
+                A = params.A + params.A_size_bytes * ID;
+                linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
+            } else
+            {
+                A = args[0] + s0 * N_;
+            }
             linearize_@TYPE@_matrix(C, args[1] + s1 * N_, &c_in);
 
             /*
@@ -2325,7 +2364,7 @@ static void
              * alpha*A'*A + beta*c
              */
              FNAME(@SYRK@)(&uplo,
-                           &trans,
+                           &params.TRANSA,
                            &params.N,
                            &params.K,
                            (void*)&@one@, // alpha (default=1.0)
@@ -2353,38 +2392,36 @@ static void
 @TYPE@_update_rankk_down(char **args, npy_intp *dimensions,
                     npy_intp *steps, void *NPY_UNUSED(func))
 {
-    @TYPE@_update_rankk_common('L', 'N', args, dimensions, steps, 0);
+    @TYPE@_update_rankk_common('L', args, dimensions, steps, 0);
 }
 
 static void
 @TYPE@_update_rankk_up(char **args, npy_intp *dimensions,
                     npy_intp *steps, void *NPY_UNUSED(func))
 {
-    @TYPE@_update_rankk_common('U', 'N', args, dimensions, steps, 0);
+    @TYPE@_update_rankk_common('U', args, dimensions, steps, 0);
 }
 
 static void
 @TYPE@_update_rankk_down_sym(char **args, npy_intp *dimensions,
                     npy_intp *steps, void *NPY_UNUSED(func))
 {
-    @TYPE@_update_rankk_common('L', 'N', args, dimensions, steps, 1);
+    @TYPE@_update_rankk_common('L', args, dimensions, steps, 1);
 }
 
 static void
 @TYPE@_update_rankk_up_sym(char **args, npy_intp *dimensions,
                     npy_intp *steps, void *NPY_UNUSED(func))
 {
-    @TYPE@_update_rankk_common('U', 'N', args, dimensions, steps, 1);
+    @TYPE@_update_rankk_common('U', args, dimensions, steps, 1);
 }
 
 
 /*
  *   uplo:  'U' - C is upper triangular matrix. 'L' - Lower triangular.
- *   trans: 'N' - No transpose, 'T' - Transpose, 'C' - Conjugate transpose.
  */
 static void
 @TYPE@_update_rankk_no_c_common(char uplo,
-                                char trans,
                                 char **args,
                                 npy_intp *dimensions,
                                 npy_intp *steps,
@@ -2395,18 +2432,11 @@ static void
 
     INIT_OUTER_LOOP_2
 
-    if (trans == 'N') {
-        n = (fortran_int) dimensions[0];
-        k = (fortran_int) dimensions[1];
-    }
-    else {
-        /* TODO: fix trans != N case. currently this branch is never called
-           because gufunc_general.py does the transpose so that this function
-           is always called with trans == 'N'
-         */
-        k = (fortran_int) dimensions[0];
-        n = (fortran_int) dimensions[1];
-    }
+    npy_intp step_n, step_k;
+    n = (fortran_int) dimensions[0];
+    k = (fortran_int) dimensions[1];
+    step_n = steps[0];
+    step_k = steps[1];
 
     if (k == 0 || n == 0)
         return; /* output array will be empty, as one of its inner dimensions will be 0 */
@@ -2429,10 +2459,16 @@ static void
         omp_set_num_threads(nthreads);
     }
 
-    if (init_syrk_params(&params, n, k, trans, steps, sot, nthreads, 1))
+    if (init_syrk_params(&params, n, k, steps, sot, nthreads, 1))
     {
         LINEARIZE_DATA_t a_in, r_out;
-        init_linearize_data(&a_in, k, n, steps[1], steps[0]);
+        if (params.A) {
+            /*
+             * Input matrix isn't dense. Since BLAS routine expects that in
+             * contiguous memory locations, flatten input into params.A.
+             */
+            init_linearize_data(&a_in, k, n, step_k, step_n);
+        }
         init_linearize_data(&r_out, n, n, steps[3], steps[2]);
 
         //BEGIN_OUTER_LOOP_2
@@ -2441,10 +2477,18 @@ static void
 
             OMP_SET_ID
 
-            void *A = params.A + params.A_size_bytes * ID;
+            void *A;
             void *C;
 
-            linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
+            if (params.A)
+            {
+                A = params.A + params.A_size_bytes * ID;
+                linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
+            } else
+            {
+                A = args[0] + s0 * N_;
+            }
+
             // params.C will be NULL: called init_syrk_params with no_C=1
             void *pC;
 
@@ -2459,7 +2503,7 @@ static void
              * alpha*A'*A + beta*c
              */
              FNAME(@SYRK@)(&uplo,
-                           &trans,
+                           &params.TRANSA,
                            &params.N,
                            &params.K,
                            (void*)&@one@, // alpha (default=1.0)
@@ -2491,29 +2535,30 @@ static void
 @TYPE@_update_rankk_no_c_down(char **args, npy_intp *dimensions,
                     npy_intp *steps, void *NPY_UNUSED(func))
 {
-    @TYPE@_update_rankk_no_c_common('L', 'N', args, dimensions, steps, 0);
+    @TYPE@_update_rankk_no_c_common('L', args, dimensions, steps, 0);
 }
 
 static void
 @TYPE@_update_rankk_no_c_up(char **args, npy_intp *dimensions,
                     npy_intp *steps, void *NPY_UNUSED(func))
 {
-    @TYPE@_update_rankk_no_c_common('U', 'N', args, dimensions, steps, 0);
+    @TYPE@_update_rankk_no_c_common('U', args, dimensions, steps, 0);
 }
 
 static void
 @TYPE@_update_rankk_no_c_down_sym(char **args, npy_intp *dimensions,
                     npy_intp *steps, void *NPY_UNUSED(func))
 {
-    @TYPE@_update_rankk_no_c_common('L', 'N', args, dimensions, steps, 1);
+    @TYPE@_update_rankk_no_c_common('L', args, dimensions, steps, 1);
 }
 
 static void
 @TYPE@_update_rankk_no_c_up_sym(char **args, npy_intp *dimensions,
                     npy_intp *steps, void *NPY_UNUSED(func))
 {
-    @TYPE@_update_rankk_no_c_common('U', 'N', args, dimensions, steps, 1);
+    @TYPE@_update_rankk_no_c_common('U', args, dimensions, steps, 1);
 }
+
 
 /**end repeat**/
 

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -1846,9 +1846,9 @@ static void
             OMP_SET_ID
 
             if (k != 0) {
-                void *pA = params.A + params.A_size_bytes * ID;
-                void *pB = params.B + params.B_size_bytes * ID;
-                void *pC = params.C + params.C_size_bytes * ID;
+                void *pA = (void*)((char*)params.A + params.A_size_bytes * ID);
+                void *pB = (void*)((char*)params.B + params.B_size_bytes * ID);
+                void *pC = (void*)((char*)params.C + params.C_size_bytes * ID);
 
                 /* just call the appropriate multiply and update pointers */
                 @typ@ *A = linearize_@TYPE@_matrix(pA, args[swapped] + sA * N_, &a_in);
@@ -2345,11 +2345,11 @@ static void
             OMP_SET_ID
 
             void *A;
-            void *C = params.C + params.C_size_bytes * ID;
+            void *C = (void*)((char*)params.C + params.C_size_bytes * ID);
 
             if (params.A)
             {
-                A = params.A + params.A_size_bytes * ID;
+                A = (void*)((char*)params.A + params.A_size_bytes * ID);
                 linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
             } else
             {
@@ -2482,7 +2482,7 @@ static void
 
             if (params.A)
             {
-                A = params.A + params.A_size_bytes * ID;
+                A = (void*)((char*)params.A + params.A_size_bytes * ID);
                 linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
             } else
             {
@@ -3279,8 +3279,8 @@ static void
 
             OMP_SET_ID
 
-            void *A = params.A + params.A_size_bytes * ID;
-            void *B = params.B + params.B_size_bytes * ID;
+            void *A = (void*)((char*)params.A + params.A_size_bytes * ID);
+            void *B = (void*)((char*)params.B + params.B_size_bytes * ID);
             fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * ID);
 
             linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
@@ -3342,8 +3342,8 @@ static void
 
             OMP_SET_ID
 
-            void *A = params.A + params.A_size_bytes * ID;
-            void *B = params.B + params.B_size_bytes * ID;
+            void *A = (void*)((char*)params.A + params.A_size_bytes * ID);
+            void *B = (void*)((char*)params.B + params.B_size_bytes * ID);
             fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * ID);
 
             linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
@@ -3403,8 +3403,8 @@ static void
 
             OMP_SET_ID
 
-            void *A = params.A + params.A_size_bytes * ID;
-            void *B = params.B + params.B_size_bytes * ID;
+            void *A = (void*)((char*)params.A + params.A_size_bytes * ID);
+            void *B = (void*)((char*)params.B + params.B_size_bytes * ID);
             fortran_int *IPIV = (fortran_int*)((char*)params.IPIV + params.IPIV_size_bytes * ID);
 
             linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
@@ -5659,8 +5659,8 @@ static void
 
             OMP_SET_ID
 
-            void *A = params.A + params.A_size_bytes * ID;
-            void *B = params.B + params.B_size_bytes * ID;
+            void *A = (void*)((char*)params.A + params.A_size_bytes * ID);
+            void *B = (void*)((char*)params.B + params.B_size_bytes * ID);
 
             linearize_@TYPE@_matrix(A, args[0] + s0 * N_, &a_in);
             linearize_@TYPE@_matrix(B, args[1] + s1 * N_, &b_in);

--- a/gulinalg/tests/test_gufunc_general.py
+++ b/gulinalg/tests/test_gufunc_general.py
@@ -577,7 +577,7 @@ class TestSyrk(TestCase):
                 assert_(r.dtype == a.dtype)
 
     def test_syrk_broadcasted(self):
-        nstack = 1
+        nstack = 16
         for sym_out in [False, True]:
             gufunc = partial(gulinalg.update_rankk, sym_out=sym_out)
             for a_trans in [True, False]:
@@ -661,7 +661,7 @@ class TestSyrk(TestCase):
                     assert_(r.dtype == a.dtype)
 
     def test_syrk_no_c_broadcasted(self):
-        nstack = 1
+        nstack = 16
         for sym_out in [False, True]:
             gufunc = partial(gulinalg.update_rankk, sym_out=sym_out)
             for a_trans in [True, False]:
@@ -712,7 +712,6 @@ class TestSyrk(TestCase):
                         else:
                             assert_allclose(np.tril(expected), r[i])
                     assert_(r.dtype == a.dtype)
-
 
     def test_syrk_wrong_shape(self):
         nstack = 3

--- a/gulinalg/tests/test_gufunc_general.py
+++ b/gulinalg/tests/test_gufunc_general.py
@@ -4,6 +4,7 @@ matrix, that leads to various combinations of matrices to test.
 """
 
 from __future__ import print_function
+from itertools import product
 from functools import partial
 from unittest import TestCase, skipIf
 import numpy as np
@@ -578,8 +579,9 @@ class TestSyrk(TestCase):
 
     def test_syrk_broadcasted(self):
         nstack = 16
-        for sym_out in [False, True]:
-            gufunc = partial(gulinalg.update_rankk, sym_out=sym_out)
+        for sym_out, workers in product([False, True], [1, -1]):
+            gufunc = partial(gulinalg.update_rankk, sym_out=sym_out,
+                             workers=workers)
             for a_trans in [True, False]:
                 for dtype in [np.float32, np.float64]:
                     a = np.array([[1., 0.],
@@ -662,8 +664,9 @@ class TestSyrk(TestCase):
 
     def test_syrk_no_c_broadcasted(self):
         nstack = 16
-        for sym_out in [False, True]:
-            gufunc = partial(gulinalg.update_rankk, sym_out=sym_out)
+        for sym_out, workers in product([False, True], [1, -1]):
+            gufunc = partial(gulinalg.update_rankk, sym_out=sym_out,
+                             workers=workers)
             for a_trans in [True, False]:
                 for dtype in [np.float32, np.float64]:
                     a = np.array([[1., 0.],
@@ -759,6 +762,13 @@ class TestSyrk(TestCase):
 
         with assert_raises(ValueError):
             gulinalg.update_rankk(a, c, transpose_type='X')
+
+    def test_syrk_invalid_workers(self):
+        nstack = 3
+        a = np.ones((3, 3), dtype=np.float64)
+
+        with assert_raises(ValueError):
+            gulinalg.update_rankk(a, workers=0)
 
 
 if __name__ == '__main__':

--- a/gulinalg/tests/test_matrix_multiply.py
+++ b/gulinalg/tests/test_matrix_multiply.py
@@ -28,6 +28,18 @@ class TestNoCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_matrix_multiply_cc_batch(self):
+        """matrix multiply two C layout matrices"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a,b)
+            a = np.ascontiguousarray(np.stack((a,) * n_outer, axis=0))
+            b = np.ascontiguousarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = gulinalg.matrix_multiply(a, b, workers=workers)
+            assert_allclose(res, ref)
 
     def test_matrix_multiply_cf(self):
         """matrix multiply C layout by FORTRAN layout matrices"""
@@ -37,6 +49,18 @@ class TestNoCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_matrix_multiply_cf_batch(self):
+        """matrix multiply two C layout matrices"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a,b)
+            a = np.ascontiguousarray(np.stack((a,) * n_outer, axis=0))
+            b = np.asfortranarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = gulinalg.matrix_multiply(a, b, workers=workers)
+            assert_allclose(res, ref)
 
     def test_matrix_multiply_fc(self):
         """matrix multiply FORTRAN layout by C layout matrices"""
@@ -46,6 +70,18 @@ class TestNoCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_matrix_multiply_fc_batch(self):
+        """matrix multiply two C layout matrices"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a,b)
+            a = np.asfortranarray(np.stack((a,) * n_outer, axis=0))
+            b = np.ascontiguousarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = gulinalg.matrix_multiply(a, b, workers=workers)
+            assert_allclose(res, ref)
 
     def test_matrix_multiply_ff(self):
         """matrix multiply two FORTRAN layout matrices"""
@@ -55,7 +91,19 @@ class TestNoCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
-    
+    def test_matrix_multiply_fc_batch(self):
+        """matrix multiply two C layout matrices"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a,b)
+            a = np.asfortranarray(np.stack((a,) * n_outer, axis=0))
+            b = np.asfortranarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = gulinalg.matrix_multiply(a, b, workers=workers)
+            assert_allclose(res, ref)
+
     # C explicit outputs =======================================================
     def test_matrix_multiply_cc_c(self):
         """matrix multiply two C layout matrices, explicit C array output"""
@@ -66,6 +114,19 @@ class TestNoCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_matrix_multiply_cc_c_batch(self):
+        """matrix multiply two C layout matrices"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a,b)
+            a = np.ascontiguousarray(np.stack((a,) * n_outer, axis=0))
+            b = np.ascontiguousarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K), order='C')
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
 
     def test_matrix_multiply_cf_c(self):
         """matrix multiply C layout by FORTRAN layout matrices, explicit C array output"""
@@ -76,6 +137,19 @@ class TestNoCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_matrix_multiply_cf_c_batch(self):
+        """matrix multiply two C layout matrices"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a,b)
+            a = np.ascontiguousarray(np.stack((a,) * n_outer, axis=0))
+            b = np.asfortranarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K), order='C')
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
 
     def test_matrix_multiply_fc_c(self):
         """matrix multiply FORTRAN layout by C layout matrices, explicit C array output"""
@@ -86,6 +160,19 @@ class TestNoCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_matrix_multiply_fc_c_batch(self):
+        """matrix multiply two C layout matrices"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a,b)
+            a = np.asfortranarray(np.stack((a,) * n_outer, axis=0))
+            b = np.ascontiguousarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K), order='C')
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
 
     def test_matrix_multiply_ff_c(self):
         """matrix multiply two FORTRAN layout matrices, explicit C array output"""
@@ -96,6 +183,19 @@ class TestNoCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_matrix_multiply_ff_c_batch(self):
+        """matrix multiply two C layout matrices"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a,b)
+            a = np.asfortranarray(np.stack((a,) * n_outer, axis=0))
+            b = np.asfortranarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K), order='C')
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
 
     # FORTRAN explicit outputs =================================================
     def test_matrix_multiply_cc_f(self):
@@ -107,6 +207,19 @@ class TestNoCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_matrix_multiply_cc_f_batch(self):
+        """matrix multiply two C layout matrices"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a,b)
+            a = np.ascontiguousarray(np.stack((a,) * n_outer, axis=0))
+            b = np.ascontiguousarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K), order='F')
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
 
     def test_matrix_multiply_cf_f(self):
         """matrix multiply C layout by FORTRAN layout matrices, explicit FORTRAN array output"""
@@ -117,6 +230,19 @@ class TestNoCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_matrix_multiply_cf_f_batch(self):
+        """matrix multiply two C layout matrices"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a,b)
+            a = np.ascontiguousarray(np.stack((a,) * n_outer, axis=0))
+            b = np.asfortranarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K), order='F')
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
 
     def test_matrix_multiply_fc_f(self):
         """matrix multiply FORTRAN layout by C layout matrices, explicit FORTRAN array output"""
@@ -127,6 +253,19 @@ class TestNoCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_matrix_multiply_fc_f_batch(self):
+        """matrix multiply two C layout matrices"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a,b)
+            a = np.asfortranarray(np.stack((a,) * n_outer, axis=0))
+            b = np.ascontiguousarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K), order='F')
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
 
     def test_matrix_multiply_ff_f(self):
         """matrix multiply two FORTRAN layout matrices, explicit FORTRAN array output"""
@@ -137,9 +276,22 @@ class TestNoCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_matrix_multiply_ff_f_batch(self):
+        """matrix multiply two C layout matrices"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a,b)
+            a = np.asfortranarray(np.stack((a,) * n_outer, axis=0))
+            b = np.asfortranarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K), order='F')
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
 
 # this class test the cases where there is at least one operand/output that
-# requires copy/rearranging. 
+# requires copy/rearranging.
 class TestWithCopy(TestCase):
     # No output specified (operation allocated) ================================
     def test_input_non_contiguous_1(self):
@@ -152,6 +304,20 @@ class TestWithCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_input_non_contiguous_1_batch(self):
+        """first input not contiguous"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N, 2)
+            b = np.random.randn(N, K)
+            ref = np.dot(a[..., 0], b)
+            a = np.ascontiguousarray(np.stack((a,) * n_outer, axis=0))[..., 0]
+            b = np.ascontiguousarray(np.stack((b,) * n_outer, axis=0))
+            assert not a.flags.c_contiguous and not a.flags.f_contiguous
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K), order='C')
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
 
     def test_input_non_contiguous_2(self):
         """second input not contiguous"""
@@ -163,6 +329,20 @@ class TestWithCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_input_non_contiguous_2_batch(self):
+        """second input not contiguous"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K, 2)
+            ref = np.dot(a, b[..., 0])
+            a = np.ascontiguousarray(np.stack((a,) * n_outer, axis=0))
+            b = np.ascontiguousarray(np.stack((b,) * n_outer, axis=0))[..., 0]
+            assert not b.flags.c_contiguous and not b.flags.f_contiguous
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K), order='C')
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
 
     def test_input_non_contiguous_3(self):
         """neither input contiguous"""
@@ -175,6 +355,21 @@ class TestWithCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_input_non_contiguous_3_batch(self):
+        """neither input contiguous"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N, 2)
+            b = np.random.randn(N, K, 2)
+            ref = np.dot(a[..., 0], b[..., 0])
+            a = np.ascontiguousarray(np.stack((a,) * n_outer, axis=0))[..., 0]
+            b = np.ascontiguousarray(np.stack((b,) * n_outer, axis=0))[..., 0]
+            assert not a.flags.c_contiguous and not a.flags.f_contiguous
+            assert not b.flags.c_contiguous and not b.flags.f_contiguous
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K), order='C')
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
 
     def test_output_non_contiguous(self):
         """output not contiguous"""
@@ -186,6 +381,20 @@ class TestWithCopy(TestCase):
         ref = np.dot(a,b)
         assert_allclose(res, ref)
 
+    def test_output_non_contiguous_batch(self):
+        """output not contiguous"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N)
+            b = np.random.randn(N, K)
+            ref = np.dot(a, b)
+            a = np.ascontiguousarray(np.stack((a,) * n_outer, axis=0))
+            b = np.ascontiguousarray(np.stack((b,) * n_outer, axis=0))
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K, 2), order='C')[..., 0]
+            assert not res.flags.c_contiguous and not res.flags.f_contiguous
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
 
     def test_all_non_contiguous(self):
         """neither input nor output contiguous"""
@@ -200,11 +409,28 @@ class TestWithCopy(TestCase):
         assert_allclose(res, ref)
 
 
+    def test_all_non_contiguous_batch(self):
+        """neither input nor output contiguous"""
+        n_outer = 4
+        for workers in [1, -1]:
+            a = np.random.randn(M, N, 2)
+            b = np.random.randn(N, K, 2)
+            ref = np.dot(a[..., 0], b[..., 0])
+            a = np.ascontiguousarray(np.stack((a,) * n_outer, axis=0))[..., 0]
+            b = np.ascontiguousarray(np.stack((b,) * n_outer, axis=0))[..., 0]
+            ref = np.stack((ref,) * n_outer, axis=0)
+            res = np.zeros((n_outer, M, K, 2), order='C')[..., 0]
+            assert not a.flags.c_contiguous and not a.flags.f_contiguous
+            assert not b.flags.c_contiguous and not b.flags.f_contiguous
+            assert not res.flags.c_contiguous and not res.flags.f_contiguous
+            gulinalg.matrix_multiply(a, b, workers=workers, out=res)
+            assert_allclose(res, ref)
+
     def test_stride_tricks(self):
         """test that matrices that are contiguous but have their dimension
         overlapped *copy*, as BLAS does not support them"""
         a = np.ascontiguousarray(np.random.randn(M + N))
-        a = np.lib.stride_tricks.as_strided(a, shape=(M,N), 
+        a = np.lib.stride_tricks.as_strided(a, shape=(M,N),
                                             strides=(a.itemsize, a.itemsize))
         b = np.ascontiguousarray(np.random.randn(N,K))
         res = gulinalg.matrix_multiply(a,b)

--- a/setup.py
+++ b/setup.py
@@ -7,16 +7,13 @@ import sys
 
 
 # note that this package depends on NumPy's distutils. It also
-# piggy-backs on NumPy configuration in order to link agains the
+# piggy-backs on NumPy configuration in order to link against the
 # appropriate BLAS/LAPACK implementation.
+from numpy.distutils.command.build_ext import build_ext
 from numpy.distutils.core import setup, Extension
 from numpy.distutils import system_info as np_sys_info
 from numpy.distutils import misc_util as np_misc_util
 from setup_helpers import add_flag_checking
-try:
-    from setuptools.command.build_ext import build_ext
-except ImportError:
-    from distutils.command.build_ext import build_ext
 
 import versioneer
 
@@ -58,6 +55,9 @@ for key, val in npymath_info.items():
         extra_opts[key].extend(val)
     else:
         extra_opts[key] = copy.deepcopy(val)
+
+# make sure the compiler can find conditional_omp.h
+extra_opts['include_dirs'] += [os.path.join(C_SRC_PATH)]
 
 extra_compile_args = []
 extra_link_args = []

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,20 @@ for key, val in npymath_info.items():
         extra_opts[key] = copy.deepcopy(val)
 
 
+extra_compile_args = []
+extra_link_args = []
+USE_OPENMP = True  # TODO: try compilation of test function to determine
+if USE_OPENMP:
+    # TODO: set compiler/platform-dependent values
+    extra_opts['libraries'] += ['gomp']
+    extra_compile_args += ['-fopenmp']
+    extra_link_args += ['-fopenmp']
+
 gufunc_module = Extension('gulinalg._impl',
                           sources = MODULE_SOURCES,
                           depends = MODULE_DEPENDENCIES,
+                          extra_compile_args=extra_compile_args,
+                          extra_link_args=extra_link_args,
                           **extra_opts)
 
 packages = [

--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -1,0 +1,180 @@
+"""Distutils / setuptools helpers.
+
+The functions in this file were borrowed from DIPY (see LICENSE)
+"""
+import os
+from os.path import join as pjoin, dirname, exists
+import tempfile
+import shutil
+
+from distutils.errors import CompileError, LinkError
+
+from distutils import log
+
+
+# Path of file to which to write C conditional vars from build-time checks
+CONFIG_H = pjoin("build", "config.h")
+# File name (no directory) to which to write Python vars from build-time checks
+CONFIG_PY = "__config__.py"
+# Directory to which to write libraries for building
+LIB_DIR_TMP = pjoin("build", "extra_libs")
+
+
+def add_flag_checking(build_ext_class, flag_defines, top_package_dir=""):
+    """ Override input `build_ext_class` to check compiler `flag_defines`
+
+    Parameters
+    ----------
+    build_ext_class : class
+        Class implementing ``distutils.command.build_ext.build_ext`` interface,
+        with a ``build_extensions`` method.
+    flag_defines : sequence
+        A sequence of elements, where the elements are sequences of length 4
+        consisting of (``compile_flags``, ``link_flags``, ``code``,
+        ``defvar``). ``compile_flags`` is a sequence of compiler flags;
+        ``link_flags`` is a sequence of linker flags. We
+        check ``compile_flags`` to see whether a C source string ``code`` will
+        compile, and ``link_flags`` to see whether the resulting object file
+        will link.  If both compile and link works, we add ``compile_flags`` to
+        ``extra_compile_args`` and ``link_flags`` to ``extra_link_args`` of
+        each extension when we build the extensions.  If ``defvar`` is not
+        None, it is the name of C variable to be defined in ``build/config.h``
+        with 1 if the combination of (``compile_flags``, ``link_flags``,
+        ``code``) will compile and link, 0 otherwise. If None, do not write
+        variable.
+    top_package_dir : str
+        String giving name of top-level package, for writing Python file
+        containing configuration variables.  If empty, do not write this file.
+        Variables written are the same as the Cython variables generated via
+        the `flag_defines` setting.
+
+    Returns
+    -------
+    checker_class : class
+        A class with similar interface to
+        ``distutils.command.build_ext.build_ext``, that adds all working
+        ``compile_flags`` values to the ``extra_compile_args`` and working
+        ``link_flags`` to ``extra_link_args`` attributes of extensions, before
+        compiling.
+    """
+
+    class Checker(build_ext_class):
+        flag_defs = tuple(flag_defines)
+
+        def can_compile_link(self, compile_flags, link_flags, code):
+            cc = self.compiler
+            fname = "test.c"
+            cwd = os.getcwd()
+            tmpdir = tempfile.mkdtemp()
+            try:
+                os.chdir(tmpdir)
+                with open(fname, "wt") as fobj:
+                    fobj.write(code)
+                try:
+                    objects = cc.compile([fname], extra_postargs=compile_flags)
+                except CompileError:
+                    return False
+                try:
+                    # Link shared lib rather then executable to avoid
+                    # http://bugs.python.org/issue4431 with MSVC 10+
+                    cc.link_shared_lib(
+                        objects, "testlib", extra_postargs=link_flags
+                    )
+                except (LinkError, TypeError):
+                    return False
+            finally:
+                os.chdir(cwd)
+                shutil.rmtree(tmpdir)
+            return True
+
+        def build_extensions(self):
+            """ Hook into extension building to check compiler flags """
+            def_vars = []
+            good_compile_flags = []
+            good_link_flags = []
+            config_dir = dirname(CONFIG_H)
+            for compile_flags, link_flags, code, def_var in self.flag_defs:
+                compile_flags = list(compile_flags)
+                link_flags = list(link_flags)
+                flags_good = self.can_compile_link(
+                    compile_flags, link_flags, code
+                )
+                if def_var:
+                    def_vars.append((def_var, flags_good))
+                if flags_good:
+                    good_compile_flags += compile_flags
+                    good_link_flags += link_flags
+                else:
+                    log.warn(
+                        "Flags {0} omitted because of compile or link "
+                        "error".format(compile_flags + link_flags)
+                    )
+            if def_vars:  # write config.h file
+                if not exists(config_dir):
+                    self.mkpath(config_dir)
+                with open(CONFIG_H, "wt") as fobj:
+                    fobj.write("/* Automatically generated; do not edit\n")
+                    fobj.write("   C defines from build-time checks */\n")
+                    for v_name, v_value in def_vars:
+                        fobj.write(
+                            "int {0} = {1};\n".format(
+                                v_name, 1 if v_value else 0
+                            )
+                        )
+            if def_vars and top_package_dir:  # write __config__.py file
+                config_py_dir = (
+                    top_package_dir
+                    if self.inplace
+                    else pjoin(self.build_lib, top_package_dir)
+                )
+                if not exists(config_py_dir):
+                    self.mkpath(config_py_dir)
+                config_py = pjoin(config_py_dir, CONFIG_PY)
+                with open(config_py, "wt") as fobj:
+                    fobj.write("# Automatically generated; do not edit\n")
+                    fobj.write("# Variables from compile checks\n")
+                    for v_name, v_value in def_vars:
+                        fobj.write("{0} = {1}\n".format(v_name, v_value))
+            if def_vars or good_compile_flags or good_link_flags:
+                for ext in self.extensions:
+                    ext.extra_compile_args += good_compile_flags
+                    ext.extra_link_args += good_link_flags
+                    if def_vars:
+                        ext.include_dirs.append(config_dir)
+            build_ext_class.build_extensions(self)
+
+    return Checker
+
+
+def make_np_ext_builder(build_ext_class):
+    """ Override input `build_ext_class` to add numpy includes to extension
+
+    This is useful to delay call of ``np.get_include`` until the extension is
+    being built.
+
+    Parameters
+    ----------
+    build_ext_class : class
+        Class implementing ``distutils.command.build_ext.build_ext`` interface,
+        with a ``build_extensions`` method.
+
+    Returns
+    -------
+    np_build_ext_class : class
+        A class with similar interface to
+        ``distutils.command.build_ext.build_ext``, that adds libraries in
+        ``np.get_include()`` to include directories of extension.
+    """
+
+    class NpExtBuilder(build_ext_class):
+        def build_extensions(self):
+            """ Hook into extension building to add np include dirs
+            """
+            # Delay numpy import until last moment
+            import numpy as np
+
+            for ext in self.extensions:
+                ext.include_dirs.append(np.get_include())
+            build_ext_class.build_extensions(self)
+
+    return NpExtBuilder

--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -1,6 +1,8 @@
 """Distutils / setuptools helpers.
 
-The functions in this file were borrowed from DIPY (see LICENSE)
+The functions in this file were borrowed from DIPY (BSD 3-clause license)
+https://github.com/dipy/dipy/blob/master/LICENSE
+
 """
 import os
 from os.path import join as pjoin, dirname, exists
@@ -144,37 +146,3 @@ def add_flag_checking(build_ext_class, flag_defines, top_package_dir=""):
             build_ext_class.build_extensions(self)
 
     return Checker
-
-
-def make_np_ext_builder(build_ext_class):
-    """ Override input `build_ext_class` to add numpy includes to extension
-
-    This is useful to delay call of ``np.get_include`` until the extension is
-    being built.
-
-    Parameters
-    ----------
-    build_ext_class : class
-        Class implementing ``distutils.command.build_ext.build_ext`` interface,
-        with a ``build_extensions`` method.
-
-    Returns
-    -------
-    np_build_ext_class : class
-        A class with similar interface to
-        ``distutils.command.build_ext.build_ext``, that adds libraries in
-        ``np.get_include()`` to include directories of extension.
-    """
-
-    class NpExtBuilder(build_ext_class):
-        def build_extensions(self):
-            """ Hook into extension building to add np include dirs
-            """
-            # Delay numpy import until last moment
-            import numpy as np
-
-            for ext in self.extensions:
-                ext.include_dirs.append(np.get_include())
-            build_ext_class.build_extensions(self)
-
-    return NpExtBuilder


### PR DESCRIPTION
### Overview
This PR uses OpenMP threads to evaluate over gufunc loop dimensions in parallel.

So far, the following functions have had multi-threading added:
- `solve`
- `inv`
- `chosolve`
- `update_rankk`
- `matrix_multiply`

### Usage
The number of threads to use can be controlled via the `workers` argument (default=1). Setting workers=-1 will use all threads (i.e. `multiprocessing.cpu_count()`).

### Installation with OpenMP support

On windows MSVC flags will be set, otherwise GCC-style flags (`-fopenmp`) are set. By default OpenMP is enabled, but if compilation of a simple test function fails, OpenMP will be disabled. 

The user can force OpenMP to always be disabled if desired by defining the environment variable `GULINALG_DISABLE_OPENMP`.

If Intel's OpenMP library should be linked to, the user should specify the environment variable GULINALG_INTEL_OPENMP. This will cause `libiomp5` to be linked during compilation (instead of GCC's `libgomp`).

### Benchmarking
Initial benchmarking on a 10-core Sklake-X CPU gives up to a ~ factor of 3 improvement in runtime for `solve` (dependent on batch size and matrix size). 

### TODO
- [x] add `matrix_multiply`
- [x] add info from above to README/INSTALL instructions
- [x] review `update_rankk` implementation to see if the efficiency can be improved
