### PR TITLE
ehancements to update_rankk (syrk)

### DIFF
--- a/gulinalg/gufunc_general.py
+++ b/gulinalg/gufunc_general.py
@@ -451,4 +451,7 @@ def update_rankk(a, c=None, UPLO='U', transpose_type='T', **kwargs):
                 gufunc = _impl.update_rankk_no_c_down
             else:
                 gufunc = _impl.update_rankk_down
-    return gufunc(a, c, **kwargs)
+    out = gufunc(a, c, **kwargs)
+    if c is None:
+        out = out.swapaxes(-1, -2)
+    return out

--- a/gulinalg/gufunc_general.py
+++ b/gulinalg/gufunc_general.py
@@ -361,7 +361,7 @@ def update_rank1(a, b, c, conjugate=True, **kwargs):
     return gufunc(a, b, c, **kwargs)
 
 
-def update_rankk(a, c=None, UPLO='U', transpose_type='N', **kwargs):
+def update_rankk(a, c=None, UPLO='U', transpose_type='T', **kwargs):
     """
     Compute symmteric rank-k update, with broadcasting
 

--- a/gulinalg/gufunc_general.py
+++ b/gulinalg/gufunc_general.py
@@ -361,7 +361,7 @@ def update_rank1(a, b, c, conjugate=True, **kwargs):
     return gufunc(a, b, c, **kwargs)
 
 
-def update_rankk(a, c, UPLO='U', transpose_type='N', **kwargs):
+def update_rankk(a, c=None, UPLO='U', transpose_type='N', **kwargs):
     """
     Compute symmteric rank-k update, with broadcasting
 
@@ -370,15 +370,12 @@ def update_rankk(a, c, UPLO='U', transpose_type='N', **kwargs):
     a : (..., N, K) or (..., K, N) array
         Input array. If `transpose_type` is 'N', `a` should be shape
         (..., N, K) otherwise it should be shape (..., K, N)
-
-    c : (..., N, N) array
-        Input array.
-
+    c : (..., N, N) array, optional
+        Input array. If None, `c` will be a zeros matrix.
     UPLO : {'U', 'L'}, optional
          Specifies whether the calculation is done with the lower
          triangular part of the elements in `a` ('L', default) or
          the upper triangular part ('U').
-
     transpose_type : {'N', 'T', 'C'}, optional
          Transpose type which decides equation to be solved.
          N => No transpose i.e. C = alpha * A * A.T + beta * C
@@ -394,8 +391,7 @@ def update_rankk(a, c, UPLO='U', transpose_type='N', **kwargs):
     -----
     Numpy broadcasting rules apply.
 
-    Implemented for single, double. Numpy conversion
-    rules apply.
+    Implemented for single, double. Numpy conversion rules apply.
 
     Rank-k update is computed using BLAS _syrk functions.
 
@@ -406,6 +402,13 @@ def update_rankk(a, c, UPLO='U', transpose_type='N', **kwargs):
     ...               [2., 3.]])
     >>> c = np.zeros((3, 3))
     >>> res = update_rankk(a, c)
+    >>> res.shape == (3, 3)
+    True
+    >>> res
+    array([[ 1.,  0.,  2.],
+           [ 0.,  4., -6.],
+           [ 0.,  0., 13.]])
+    >>> res = update_rankk(a)
     >>> res.shape == (3, 3)
     True
     >>> res
@@ -425,7 +428,7 @@ def update_rankk(a, c, UPLO='U', transpose_type='N', **kwargs):
                           "valid values are: %s") %
                          (transpose_type, transpose_choices))
 
-    if a.dtype.kind == 'c' or c.dtype.kind == 'c':
+    if a.dtype.kind == 'c' or (c is not None and c.dtype.kind == 'c'):
         raise NotImplementedError(
             "complex-value support not currently implemented")
 
@@ -439,7 +442,13 @@ def update_rankk(a, c, UPLO='U', transpose_type='N', **kwargs):
 
     if transpose_type == 'N':
         if UPLO == 'U':
-            gufunc = _impl.update_rankk_up
+            if c is None:
+                gufunc = _impl.update_rankk_no_c_up
+            else:
+                gufunc = _impl.update_rankk_up
         else:
-            gufunc = _impl.update_rankk_down
+            if c is None:
+                gufunc = _impl.update_rankk_no_c_down
+            else:
+                gufunc = _impl.update_rankk_down
     return gufunc(a, c, **kwargs)

--- a/gulinalg/gufunc_general.py
+++ b/gulinalg/gufunc_general.py
@@ -405,20 +405,20 @@ def update_rankk(a, c=None, UPLO='U', transpose_type='T', sym_out=True,
     ...               [0., -2.],
     ...               [2., 3.]])
     >>> c = np.zeros((3, 3))
-    >>> res = update_rankk(a, c)
+    >>> res = update_rankk(a, c, transpose_type='N', sym_out=False)
     >>> res.shape == (3, 3)
     True
     >>> res
     array([[ 1.,  0.,  2.],
            [ 0.,  4., -6.],
            [ 0.,  0., 13.]])
-    >>> res = update_rankk(a)
+    >>> res = update_rankk(a, transpose_type='N', sym_out=True)
     >>> res.shape == (3, 3)
     True
     >>> res
     array([[ 1.,  0.,  2.],
            [ 0.,  4., -6.],
-           [ 0.,  0., 13.]])
+           [ 2., -6., 13.]])
     """
     uplo_choices = ['U', 'L']
     transpose_choices = ['N', 'T', 'C']

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -2128,20 +2128,16 @@ init_syrk_params(SYRK_PARAMS_t *params,
                  npy_intp* steps,
                  size_t sot)
 {
-    npy_uint8 *mem_buff = malloc(n * k * sot);
+    size_t a_size = n * k * sot;
+    size_t c_size = n * n * sot;
+    npy_uint8 *mem_buff = malloc(a_size + c_size);
     if (!mem_buff) {
         memset(params, 0, sizeof(*params));
         return 0;
     }
 
-    npy_uint8 *mem_buff2 = malloc(n * n * sot);
-    if (!mem_buff2) {
-        memset(params, 0, sizeof(*params));
-        return 0;
-    }
-
     params->A = mem_buff;
-    params->C = mem_buff2;
+    params->C = mem_buff + a_size;
     if (trans=='N'){
         params->LDA = n;  // must be at least max(1, n)
     } else {
@@ -2159,8 +2155,6 @@ release_syrk_params(SYRK_PARAMS_t * params)
 {
     free(params->A);
     params->A = NULL;
-    free(params->C);
-    params->C = NULL;
 }
 
 /**begin repeat
@@ -3375,7 +3369,8 @@ init_getrf_func(GETRF_PARAMS_t *params, fortran_int M, fortran_int N,
     const size_t a_size = M * N * sot;
     fortran_int min_m_n = M < N ? M:N;
     const size_t ipiv_size = min_m_n * sizeof(fortran_int);
-    npy_uint8 *mem_buff = malloc(a_size + ipiv_size);
+    npy_uint8 *mem_buff = NULL;
+    mem_buff = malloc(a_size + ipiv_size);
 
     if (mem_buff == NULL) {
         free(mem_buff);
@@ -3390,6 +3385,7 @@ init_getrf_func(GETRF_PARAMS_t *params, fortran_int M, fortran_int N,
     params->LDA = M;
 
     return 1;
+
 }
 
 static inline void

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -2250,6 +2250,90 @@ static void
 }
 
 
+/*
+ *   uplo:  'U' - C is upper triangular matrix. 'L' - Lower triangular.
+ *   trans: 'N' - No transpose, 'T' - Transpose, 'C' - Conjugate transpose.
+ */
+static void
+@TYPE@_update_rankk_no_c_common(char uplo,
+                                char trans,
+                                char **args,
+                                npy_intp *dimensions,
+                                npy_intp *steps)
+{
+    SYRK_PARAMS_t params;
+    fortran_int k, n;
+
+    INIT_OUTER_LOOP_2
+
+    if (trans == 'N') {
+        n = (fortran_int) dimensions[0];
+        k = (fortran_int) dimensions[1];
+    }
+    else {
+        /* TODO: fix trans != N case. currently this branch is never called
+           because gufunc_general.py does the transpose so that this function
+           is always called with trans == 'N'
+         */
+        k = (fortran_int) dimensions[0];
+        n = (fortran_int) dimensions[1];
+    }
+
+    if (k == 0 || n == 0)
+        return; /* output array will be empty, as one of its inner dimensions will be 0 */
+
+    size_t sot = sizeof(@typ@);
+
+    if (init_syrk_params(&params, n, k, trans, steps, sot))
+    {
+        LINEARIZE_DATA_t a_in, r_out;
+        init_linearize_data(&a_in, k, n, steps[1], steps[0]);
+        init_linearize_data(&r_out, n, n, steps[3], steps[2]);
+
+        BEGIN_OUTER_LOOP_2
+            linearize_@TYPE@_matrix(params.A, args[0], &a_in);
+            // linearize_@TYPE@_matrix(params.C, args[1], &a_in);
+            zero_@TYPE@_matrix(params.C, &r_out);
+
+            /*
+             * To get rank-k update, invoke syrk_.
+             * alpha*A*A' + beta*C
+             * or
+             * alpha*A'*A + beta*c
+             */
+             FNAME(@SYRK@)(&uplo,
+                           &trans,
+                           &params.N,
+                           &params.K,
+                           (void*)&@one@, // alpha (default=1.0)
+                           params.A,
+                           &params.LDA,
+                           (void*)&@zero@, // beta (default=0.0)
+                           params.C,
+                           &params.LDC);
+
+            /* Copy Fortran matrix returned by SYRK to output argument */
+            delinearize_@TYPE@_matrix(args[1], params.C, &r_out);
+        END_OUTER_LOOP
+
+        release_syrk_params(&params);
+    }
+}
+
+static void
+@TYPE@_update_rankk_no_c_down(char **args, npy_intp *dimensions,
+                    npy_intp *steps, void *NPY_UNUSED(func))
+{
+    @TYPE@_update_rankk_no_c_common('L', 'N', args, dimensions, steps);
+}
+
+static void
+@TYPE@_update_rankk_no_c_up(char **args, npy_intp *dimensions,
+                    npy_intp *steps, void *NPY_UNUSED(func))
+{
+    @TYPE@_update_rankk_no_c_common('U', 'N', args, dimensions, steps);
+}
+
 /**end repeat**/
 
 
@@ -5767,6 +5851,8 @@ GUFUNC_FUNC_ARRAY_REAL_COMPLEX(update_rank1);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX(update_rank1_conjugate);
 GUFUNC_FUNC_ARRAY_REAL(update_rankk_down);
 GUFUNC_FUNC_ARRAY_REAL(update_rankk_up);
+GUFUNC_FUNC_ARRAY_REAL(update_rankk_no_c_down);
+GUFUNC_FUNC_ARRAY_REAL(update_rankk_no_c_up);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX(slogdet);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX(det);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX(eighlo);
@@ -6024,6 +6110,24 @@ static GUFUNC_DESCRIPTOR_t gufunc_descriptors [] = {
         2, 2, 1,
         FUNC_ARRAY_NAME(update_rankk_up),
         equal_3_types
+    },
+    {
+        "update_rankk_no_c_down",
+        "(n,k)->(n,n)",
+        "multiply symmetric matrices \n"\
+        "    \"(n,k)->(n,n)\" \n",
+        2, 1, 1,
+        FUNC_ARRAY_NAME(update_rankk_no_c_down),
+        equal_2_types
+    },
+    {
+        "update_rankk_no_c_up",
+        "(n,k)->(n,n)",
+        "multiply symmetric matrices \n"\
+        "    \"(n,k)->(n,n)\" \n",
+        2, 1, 1,
+        FUNC_ARRAY_NAME(update_rankk_no_c_up),
+        equal_2_types
     },
     {
         "slogdet",

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -2175,7 +2175,8 @@ static void
                            char trans,
                            char **args,
                            npy_intp *dimensions,
-                           npy_intp *steps)
+                           npy_intp *steps,
+                           int symmetric)
 {
     SYRK_PARAMS_t params;
     fortran_int k, n;
@@ -2229,6 +2230,10 @@ static void
                            &params.LDC);
 
             /* Copy Fortran matrix returned by SYRK to output argument */
+            if (symmetric)
+            {
+                make_symmetric_@TYPE@_matrix(uplo, params.N, params.C);
+            }
             delinearize_@TYPE@_matrix(args[2], params.C, &r_out);
         END_OUTER_LOOP
 
@@ -2240,14 +2245,28 @@ static void
 @TYPE@_update_rankk_down(char **args, npy_intp *dimensions,
                     npy_intp *steps, void *NPY_UNUSED(func))
 {
-    @TYPE@_update_rankk_common('L', 'N', args, dimensions, steps);
+    @TYPE@_update_rankk_common('L', 'N', args, dimensions, steps, 0);
 }
 
 static void
 @TYPE@_update_rankk_up(char **args, npy_intp *dimensions,
                     npy_intp *steps, void *NPY_UNUSED(func))
 {
-    @TYPE@_update_rankk_common('U', 'N', args, dimensions, steps);
+    @TYPE@_update_rankk_common('U', 'N', args, dimensions, steps, 0);
+}
+
+static void
+@TYPE@_update_rankk_down_sym(char **args, npy_intp *dimensions,
+                    npy_intp *steps, void *NPY_UNUSED(func))
+{
+    @TYPE@_update_rankk_common('L', 'N', args, dimensions, steps, 1);
+}
+
+static void
+@TYPE@_update_rankk_up_sym(char **args, npy_intp *dimensions,
+                    npy_intp *steps, void *NPY_UNUSED(func))
+{
+    @TYPE@_update_rankk_common('U', 'N', args, dimensions, steps, 1);
 }
 
 
@@ -2260,7 +2279,8 @@ static void
                                 char trans,
                                 char **args,
                                 npy_intp *dimensions,
-                                npy_intp *steps)
+                                npy_intp *steps,
+                                int symmetric)
 {
     SYRK_PARAMS_t params;
     fortran_int k, n;
@@ -2285,7 +2305,9 @@ static void
 
     size_t sot = sizeof(@typ@);
 
-    if (init_syrk_params(&params, n, k, trans, steps, sot, 1))
+
+    int avoid_C_allocation = 1;
+    if (init_syrk_params(&params, n, k, trans, steps, sot, avoid_C_allocation))
     {
         LINEARIZE_DATA_t a_in, r_out;
         init_linearize_data(&a_in, k, n, steps[1], steps[0]);
@@ -2293,10 +2315,21 @@ static void
 
         BEGIN_OUTER_LOOP_2
             linearize_@TYPE@_matrix(params.A, args[0], &a_in);
-            // linearize_@TYPE@_matrix(params.C, args[1], &a_in);
-            // zero_@TYPE@_matrix(params.C, &r_out);
 
-            zero_@TYPE@_matrix(args[1], &r_out);
+
+            // params.C will be NULL: called init_syrk_params with no_C=1
+            void *pC;
+            if (avoid_C_allocation)
+            {
+                // operate on the output array directly
+                zero_@TYPE@_matrix(args[1], &r_out);
+                pC = args[1];
+            } else {
+                linearize_@TYPE@_matrix(params.C, args[1], &a_in);
+                zero_@TYPE@_matrix(params.C, &r_out);
+                pC = params.C;
+            }
+
 
             /*
              * To get rank-k update, invoke syrk_.
@@ -2312,14 +2345,21 @@ static void
                            params.A,
                            &params.LDA,
                            (void*)&@zero@, // beta (default=0.0)
-                           (void*)args[1],
+                           pC,  // C
                            &params.LDC);
 
-            /* Copy Fortran matrix returned by SYRK to output argument */
+            if (symmetric)
+            {
+                make_symmetric_@TYPE@_matrix(uplo, params.N, pC);
+            }
 
-            // If we don't call delinearize here using params.C, then we will
-            // have to call out.swapaxes(-2, -1) in the Python caller
-            //delinearize_@TYPE@_matrix(args[1], params.C, &r_out);
+            /* Copy Fortran matrix returned by SYRK to output argument */
+            /* when parms.C is NULL we will have to call
+             * out.swapaxes(-2, -1) in the Python caller
+             */
+            if (avoid_C_allocation == 0) {
+                delinearize_@TYPE@_matrix(args[1], params.C, &r_out);
+            }
         END_OUTER_LOOP
 
         release_syrk_params(&params);
@@ -2330,14 +2370,28 @@ static void
 @TYPE@_update_rankk_no_c_down(char **args, npy_intp *dimensions,
                     npy_intp *steps, void *NPY_UNUSED(func))
 {
-    @TYPE@_update_rankk_no_c_common('L', 'N', args, dimensions, steps);
+    @TYPE@_update_rankk_no_c_common('L', 'N', args, dimensions, steps, 0);
 }
 
 static void
 @TYPE@_update_rankk_no_c_up(char **args, npy_intp *dimensions,
                     npy_intp *steps, void *NPY_UNUSED(func))
 {
-    @TYPE@_update_rankk_no_c_common('U', 'N', args, dimensions, steps);
+    @TYPE@_update_rankk_no_c_common('U', 'N', args, dimensions, steps, 0);
+}
+
+static void
+@TYPE@_update_rankk_no_c_down_sym(char **args, npy_intp *dimensions,
+                    npy_intp *steps, void *NPY_UNUSED(func))
+{
+    @TYPE@_update_rankk_no_c_common('L', 'N', args, dimensions, steps, 1);
+}
+
+static void
+@TYPE@_update_rankk_no_c_up_sym(char **args, npy_intp *dimensions,
+                    npy_intp *steps, void *NPY_UNUSED(func))
+{
+    @TYPE@_update_rankk_no_c_common('U', 'N', args, dimensions, steps, 1);
 }
 
 /**end repeat**/
@@ -5857,8 +5911,12 @@ GUFUNC_FUNC_ARRAY_REAL_COMPLEX(update_rank1);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX(update_rank1_conjugate);
 GUFUNC_FUNC_ARRAY_REAL(update_rankk_down);
 GUFUNC_FUNC_ARRAY_REAL(update_rankk_up);
+GUFUNC_FUNC_ARRAY_REAL(update_rankk_down_sym);
+GUFUNC_FUNC_ARRAY_REAL(update_rankk_up_sym);
 GUFUNC_FUNC_ARRAY_REAL(update_rankk_no_c_down);
 GUFUNC_FUNC_ARRAY_REAL(update_rankk_no_c_up);
+GUFUNC_FUNC_ARRAY_REAL(update_rankk_no_c_down_sym);
+GUFUNC_FUNC_ARRAY_REAL(update_rankk_no_c_up_sym);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX(slogdet);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX(det);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX(eighlo);
@@ -6118,6 +6176,26 @@ static GUFUNC_DESCRIPTOR_t gufunc_descriptors [] = {
         equal_3_types
     },
     {
+        "update_rankk_down_sym",
+        "(n,k),(n,n)->(n,n)",
+        "rank-k update on last two dimensions and broadcast on the rest \n"\
+        "this variant has symmetric rather than triangular output"\
+        "    \"(n,k),(n,n)->(n,n)\" \n",
+        2, 2, 1,
+        FUNC_ARRAY_NAME(update_rankk_down_sym),
+        equal_3_types
+    },
+    {
+        "update_rankk_up_sym",
+        "(n,k),(n,n)->(n,n)",
+        "rank-k update on last two dimensions and broadcast on the rest \n"\
+        "this variant has symmetric rather than triangular output"\
+        "    \"(n,k),(k,n)->(n,n)\" \n",
+        2, 2, 1,
+        FUNC_ARRAY_NAME(update_rankk_up_sym),
+        equal_3_types
+    },
+    {
         "update_rankk_no_c_down",
         "(n,k)->(n,n)",
         "multiply symmetric matrices \n"\
@@ -6133,6 +6211,26 @@ static GUFUNC_DESCRIPTOR_t gufunc_descriptors [] = {
         "    \"(n,k)->(n,n)\" \n",
         2, 1, 1,
         FUNC_ARRAY_NAME(update_rankk_no_c_up),
+        equal_2_types
+    },
+    {
+        "update_rankk_no_c_down_sym",
+        "(n,k)->(n,n)",
+        "multiply symmetric matrices \n"\
+        "this variant has symmetric rather than triangular output"\
+        "    \"(n,k)->(n,n)\" \n",
+        2, 1, 1,
+        FUNC_ARRAY_NAME(update_rankk_no_c_down_sym),
+        equal_2_types
+    },
+    {
+        "update_rankk_no_c_up_sym",
+        "(n,k)->(n,n)",
+        "multiply symmetric matrices \n"\
+        "this variant has symmetric rather than triangular output"\
+        "    \"(n,k)->(n,n)\" \n",
+        2, 1, 1,
+        FUNC_ARRAY_NAME(update_rankk_no_c_up_sym),
         equal_2_types
     },
     {

--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -2126,10 +2126,11 @@ init_syrk_params(SYRK_PARAMS_t *params,
                  fortran_int k,
                  char trans,
                  npy_intp* steps,
-                 size_t sot)
+                 size_t sot,
+                 int no_C)
 {
     size_t a_size = n * k * sot;
-    size_t c_size = n * n * sot;
+    size_t c_size = no_C ? 0 : n * n * sot;
     npy_uint8 *mem_buff = malloc(a_size + c_size);
     if (!mem_buff) {
         memset(params, 0, sizeof(*params));
@@ -2137,7 +2138,7 @@ init_syrk_params(SYRK_PARAMS_t *params,
     }
 
     params->A = mem_buff;
-    params->C = mem_buff + a_size;
+    params->C = no_C ? NULL: mem_buff + a_size;
     if (trans=='N'){
         params->LDA = n;  // must be at least max(1, n)
     } else {
@@ -2199,7 +2200,7 @@ static void
 
     size_t sot = sizeof(@typ@);
 
-    if (init_syrk_params(&params, n, k, trans, steps, sot))
+    if (init_syrk_params(&params, n, k, trans, steps, sot, 0))
     {
         LINEARIZE_DATA_t a_in, c_in, r_out;
         init_linearize_data(&a_in, k, n, steps[1], steps[0]);
@@ -2284,7 +2285,7 @@ static void
 
     size_t sot = sizeof(@typ@);
 
-    if (init_syrk_params(&params, n, k, trans, steps, sot))
+    if (init_syrk_params(&params, n, k, trans, steps, sot, 1))
     {
         LINEARIZE_DATA_t a_in, r_out;
         init_linearize_data(&a_in, k, n, steps[1], steps[0]);
@@ -2293,7 +2294,9 @@ static void
         BEGIN_OUTER_LOOP_2
             linearize_@TYPE@_matrix(params.A, args[0], &a_in);
             // linearize_@TYPE@_matrix(params.C, args[1], &a_in);
-            zero_@TYPE@_matrix(params.C, &r_out);
+            // zero_@TYPE@_matrix(params.C, &r_out);
+
+            zero_@TYPE@_matrix(args[1], &r_out);
 
             /*
              * To get rank-k update, invoke syrk_.
@@ -2309,11 +2312,14 @@ static void
                            params.A,
                            &params.LDA,
                            (void*)&@zero@, // beta (default=0.0)
-                           params.C,
+                           (void*)args[1],
                            &params.LDC);
 
             /* Copy Fortran matrix returned by SYRK to output argument */
-            delinearize_@TYPE@_matrix(args[1], params.C, &r_out);
+
+            // If we don't call delinearize here using params.C, then we will
+            // have to call out.swapaxes(-2, -1) in the Python caller
+            //delinearize_@TYPE@_matrix(args[1], params.C, &r_out);
         END_OUTER_LOOP
 
         release_syrk_params(&params);

--- a/gulinalg/tests/test_gufunc_general.py
+++ b/gulinalg/tests/test_gufunc_general.py
@@ -684,11 +684,17 @@ class TestSyrk(TestCase):
                 if a_trans:
                     a = a.T
 
-                # use wrong axis size for c
+                # use wrong axis size for c when transpose_type='N'
                 c = np.zeros((a.shape[-1],)*2, dtype=dtype)
 
                 with assert_raises(ValueError):
-                    gulinalg.update_rankk(a, c)
+                    gulinalg.update_rankk(a, c, transpose_type='N')
+
+                # use wrong axis size for c when transpose_type='T'
+                c = np.zeros((a.shape[0],)*2, dtype=dtype)
+
+                with assert_raises(ValueError):
+                    gulinalg.update_rankk(a, c, transpose_type='T')
 
     def test_syrk_wrong_dtype(self):
         nstack = 3

--- a/gulinalg/tests/test_gufunc_general.py
+++ b/gulinalg/tests/test_gufunc_general.py
@@ -504,7 +504,7 @@ class TestUpdateRank1Vector(TestCase):
 
 class TestSyrk(TestCase):
 
-    def test_syrk_N_zeros_c(self):
+    def test_syrk_zeros_c(self):
         for a_trans in [True, False]:
             for dtype in [np.float32, np.float64]:
                 a = np.array([[1., 0.],
@@ -536,7 +536,7 @@ class TestSyrk(TestCase):
                 assert_allclose(np.tril(expected), r)
                 assert_(r.dtype == a.dtype)
 
-    def test_syrk_N_ones_c(self):
+    def test_syrk_ones_c(self):
         for a_trans in [True, False]:
             for dtype in [np.float32, np.float64]:
                 a = np.array([[1., 0.],
@@ -573,8 +573,8 @@ class TestSyrk(TestCase):
                 assert_allclose(expected_lower, r)
                 assert_(r.dtype == a.dtype)
 
-    def test_syrk_N_broadcasted(self):
-        nstack = 3
+    def test_syrk_broadcasted(self):
+        nstack = 1
         for a_trans in [True, False]:
             for dtype in [np.float32, np.float64]:
                 a = np.array([[1., 0.],
@@ -586,12 +586,11 @@ class TestSyrk(TestCase):
                 expected = np.dot(a, a.swapaxes(-1, -2)) + c
 
                 a = np.stack((a, ) * nstack, axis=0)  # stack
-                expected = np.stack((expected, ) * nstack, axis=0)  # stack
 
                 # test upper triangular case
                 r = gulinalg.update_rankk(a, c, transpose_type='N', UPLO='U')
                 for i in range(nstack):
-                    assert_allclose(np.triu(expected[i]), r[i])
+                    assert_allclose(np.triu(expected), r[i])
                 assert_(r.dtype == a.dtype)
 
                 # test upper triangular case with extra c dimensions
@@ -599,28 +598,81 @@ class TestSyrk(TestCase):
                 r = gulinalg.update_rankk(a, c_4d, transpose_type='N',
                                           UPLO='U')
                 for i in range(nstack):
-                    assert_allclose(np.triu(expected[i]), r[0][i])
+                    assert_allclose(np.triu(expected), r[0][i])
                 assert_(r.dtype == a.dtype)
 
                 # test lower triangular case
                 r = gulinalg.update_rankk(a, c, transpose_type='N', UPLO='L')
                 for i in range(nstack):
-                    assert_allclose(np.tril(expected[i]), r[i])
+                    assert_allclose(np.tril(expected), r[i])
                 assert_(r.dtype == a.dtype)
 
                 # test upper triangular case with transpose_type='T'
                 r = gulinalg.update_rankk(a.swapaxes(-1, -2), c,
                                           transpose_type='T', UPLO='U')
                 for i in range(nstack):
-                    assert_allclose(np.triu(expected[i]), r[i])
+                    assert_allclose(np.triu(expected), r[i])
+                assert_(r.dtype == a.dtype)
+
+                # test lower triangular case
+                r = gulinalg.update_rankk(a, c, transpose_type='N', UPLO='L')
+                for i in range(nstack):
+                    assert_allclose(np.tril(expected), r[i])
+                assert_(r.dtype == a.dtype)
+
+                # test upper triangular case with transpose_type='T'
+                r = gulinalg.update_rankk(a.swapaxes(-1, -2), c,
+                                          transpose_type='T', UPLO='U')
+                for i in range(nstack):
+                    assert_allclose(np.triu(expected), r[i])
                 assert_(r.dtype == a.dtype)
 
                 # test lower triangular case with transpose_type='T'
                 r = gulinalg.update_rankk(a.swapaxes(-1, -2), c,
                                           transpose_type='T', UPLO='L')
                 for i in range(nstack):
-                    assert_allclose(np.tril(expected[i]), r[i])
+                    assert_allclose(np.tril(expected), r[i])
                 assert_(r.dtype == a.dtype)
+
+    def test_syrk_no_c_broadcasted(self):
+        nstack = 1
+        for a_trans in [True, False]:
+            for dtype in [np.float32, np.float64]:
+                a = np.array([[1., 0.],
+                              [0., -2.],
+                              [2., 3.]], dtype=dtype)
+                if a_trans:
+                    a = a.T
+                c = np.zeros((a.shape[0],)*2, dtype=dtype)
+                expected = np.dot(a, a.swapaxes(-1, -2)) + c
+
+                a = np.stack((a, ) * nstack, axis=0)  # stack
+
+                # test upper triangular case
+                r = gulinalg.update_rankk(a, transpose_type='N', UPLO='U')
+                for i in range(nstack):
+                    assert_allclose(np.triu(expected), r[i])
+                assert_(r.dtype == a.dtype)
+
+                # test lower triangular case
+                r = gulinalg.update_rankk(a, transpose_type='N', UPLO='L')
+                for i in range(nstack):
+                    assert_allclose(np.tril(expected), r[i])
+                assert_(r.dtype == a.dtype)
+
+                # test upper triangular case with transpose_type='T'
+                r = gulinalg.update_rankk(a.swapaxes(-1, -2),
+                                          transpose_type='T', UPLO='U')
+                for i in range(nstack):
+                    assert_allclose(np.triu(expected), r[i])
+                assert_(r.dtype == a.dtype)
+
+                # test lower triangular case
+                r = gulinalg.update_rankk(a, transpose_type='N', UPLO='L')
+                for i in range(nstack):
+                    assert_allclose(np.tril(expected), r[i])
+                assert_(r.dtype == a.dtype)
+
 
     def test_syrk_wrong_shape(self):
         nstack = 3


### PR DESCRIPTION
- change `transpose_type` default from 'N' to 'T'
- Add new symmetric output option, `sym_out`, defaulting to True
- making specification of `c` optional. When `c=None` (default), a simpler underlying `gufunc` is used. This can give a modest performance improvement over the case when `c` is provided.
